### PR TITLE
Add Cursor Cloud dev environment setup notes (AGENTS.md)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,46 @@
+# AGENTS.md
+
+General project, build, and architecture guidance lives in `README.md`, `CLAUDE.md`,
+`pipeline/README.md`, and `docs/architecture.md`. Read those first.
+
+## Cursor Cloud specific instructions
+
+This repo has two services:
+
+1. **Evidence.dev frontend** (root) — the data dashboard. Node ≥18. Standard commands are in
+   `package.json` (`npm run sources`, `npm run dev`, `npm run build`). Dev server runs on port 3000.
+2. **DLT data pipelines** (`pipeline/`) — Python collectors (GitHub / Slack / citations), managed
+   with `uv`. Standard commands are in `pipeline/README.md` (`uv run nf_core_stats <cmd> --help`).
+   Lint with `uvx ruff check` (config in `pipeline/pyproject.toml`); full hooks in `.pre-commit-config.yaml`.
+
+The update script already installs `uv`, runs `npm install`, and `uv sync --project pipeline`.
+
+### Data source / MotherDuck caveat (most important)
+
+The committed `sources/nfcore_db/connection.yaml` points at **MotherDuck** (cloud DuckDB, database
+`nf_core_stats_bot`). `npm run sources` and `npm run build` need a MotherDuck token to fetch data;
+without it those queries fail. Supply the token via the gitignored `sources/nfcore_db/connection.options.yaml`,
+a root `.env` (`MOTHERDUCK_TOKEN`), or the Evidence settings UI. There is no local Postgres/Redis to
+start — the only data backend is MotherDuck.
+
+### Running fully locally without MotherDuck
+
+You can exercise both services end-to-end without the MotherDuck token:
+
+- The DLT CLI resolves `SOURCES__GITHUB_PIPELINE__GITHUB__API_TOKEN` at **import time**, so even
+  `--help` fails unless it is set. In Cloud, `gh` is authenticated, so
+  `export SOURCES__GITHUB_PIPELINE__GITHUB__API_TOKEN=$(gh auth token)` works for the `github` and
+  `citations` pipelines (the `slack` pipeline needs a real Slack admin token).
+- Run a pipeline into a local DuckDB file named `nf_core_stats_bot.duckdb` so the `USE nf_core_stats_bot;`
+  prefix in `sources/nfcore_db/*.sql` resolves (DuckDB's catalog name is the file stem):
+  `DESTINATION__DUCKDB__CREDENTIALS="$PWD/nf_core_stats_bot.duckdb" uv run nf_core_stats github --destination duckdb --resources nfcore_pipelines --resources org_members`
+- Temporarily point the frontend at that file (do **not** commit this) by setting
+  `sources/nfcore_db/connection.yaml` to `type: duckdb` with `options.filename` **relative to the
+  source directory** (e.g. `../../pipeline/nf_core_stats_bot.duckdb`), then `npm run sources && npm run dev`.
+
+Note: several source queries reference tables only filled by heavier pipeline runs
+(`github.traffic_stats`, `github.issue_stats`, `github.contributor_stats`, `slack.workspace_stats`,
+legacy `twitter.account_stats`) and one references a legacy `nf_core_dev` catalog (`pipeline_timeline`).
+These error when that data is absent — that is expected, not a setup failure. Pages backed only by
+`github.nfcore_pipelines` / `github.org_members` (e.g. `/code/pipelines`) render fully with just the
+lightweight pipeline run above.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -19,9 +19,14 @@ The update script already installs `uv`, runs `npm install`, and `uv sync --proj
 
 The committed `sources/nfcore_db/connection.yaml` points at **MotherDuck** (cloud DuckDB, database
 `nf_core_stats_bot`). `npm run sources` and `npm run build` need a MotherDuck token to fetch data;
-without it those queries fail. Supply the token via the gitignored `sources/nfcore_db/connection.options.yaml`,
-a root `.env` (`MOTHERDUCK_TOKEN`), or the Evidence settings UI. There is no local Postgres/Redis to
-start — the only data backend is MotherDuck.
+without it those queries fail. There is no local Postgres/Redis to start — the only data backend is MotherDuck.
+
+Supply the token with the env var **`EVIDENCE_SOURCE__nfcore_db__token`** (set it to the MotherDuck
+token, e.g. `export EVIDENCE_SOURCE__nfcore_db__token="$MOTHERDUCK_TOKEN"`), then run `npm run sources`
+/ `npm run dev`. Gotcha: do **not** put the raw token in `sources/nfcore_db/connection.options.yaml` —
+Evidence runs that file's values through a base64 decode, so a raw JWT makes it throw
+"Error parsing connection.options.yaml". The env-var form is set verbatim and is the reliable path.
+With the token, all source queries (GitHub, Slack, Twitter, traffic, issues, contributors) populate.
 
 ### Running fully locally without MotherDuck
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What

Sets up the development environment for this repo (Evidence.dev frontend + DLT pipelines) and documents durable, non-obvious setup/run guidance for future Cloud agents in a new `AGENTS.md`.

No application code is changed — this only adds `AGENTS.md`. The environment update script (install `uv`, `npm install`, `uv sync --project pipeline`) is registered separately via the Cloud environment config.

## Verification

Both services were installed and run end-to-end:

- **Frontend (root)** — canonical production-parity loop: `npm install`, `npm run sources`, `npm run dev` (port 3000) against the **real MotherDuck database** (token supplied via `EVIDENCE_SOURCE__nfcore_db__token`). All source queries populated (e.g. 331,521 contributor rows, 105,573 traffic rows, 4,958 Slack rows, 1,371 Twitter rows). The dashboard renders fully with no missing-table errors: 1,891 GitHub org members, 1,776 active Slack users, 197 pipelines, 131,623 commits.
- **Pipeline (`pipeline/`)** — `uv sync` + `uvx ruff check` (passes) + a live `github` collection into a local DuckDB produced real nf-core data (139 pipelines, 56 core repos, 159 org members; top repo `rnaseq` 1312 stars). The `github`/`citations` collectors authenticate via the `gh` CLI token; the `slack` collector needs `SOURCES__SLACK_PIPELINE__SLACK__API_TOKEN`.

Demo of the dashboard (the saved video shows the `/code/pipelines` page; screenshots show the full MotherDuck-backed dashboard):

[evidence_dashboard_pipelines_demo.mp4](https://cursor.com/agents/bc-9cb9bbdb-2dbd-490b-ab4d-0f3d89dd78d2/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fevidence_dashboard_pipelines_demo.mp4)

[Overview homepage with real data](https://cursor.com/agents/bc-9cb9bbdb-2dbd-490b-ab4d-0f3d89dd78d2/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fdashboard_overview_real_data.webp)
[GitHub members growth](https://cursor.com/agents/bc-9cb9bbdb-2dbd-490b-ab4d-0f3d89dd78d2/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fdashboard_github_members.webp)
[Slack users over time](https://cursor.com/agents/bc-9cb9bbdb-2dbd-490b-ab4d-0f3d89dd78d2/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fdashboard_slack_users.webp)

## Notes

- `AGENTS.md` documents the MotherDuck-token mechanism (use the `EVIDENCE_SOURCE__nfcore_db__token` env var; the raw token must NOT go in `connection.options.yaml`, which Evidence base64-decodes) and a fully-local fallback using a local DuckDB.
- The `slack` collector pipeline requires a Slack admin token not present in this VM session; its data is already visible in the dashboard via MotherDuck, so this is non-blocking.

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#team-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-9cb9bbdb-2dbd-490b-ab4d-0f3d89dd78d2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-9cb9bbdb-2dbd-490b-ab4d-0f3d89dd78d2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

