### PR TITLE
Migrate strict-syntax-health into stats repo

### DIFF
--- a/.github/workflows/lint_strict_syntax.yml
+++ b/.github/workflows/lint_strict_syntax.yml
@@ -81,10 +81,21 @@ jobs:
           python-version: "3.12"
           enable-cache: true
 
+      - name: Install runitor
+        env:
+          RUNITOR_VERSION: "v1.3.0-build.4"
+        run: |
+          curl -fsSL -o runitor \
+            "https://github.com/bdd/runitor/releases/download/${RUNITOR_VERSION}/runitor-${RUNITOR_VERSION}-linux-amd64"
+          chmod +x runitor
+          ./runitor -version
+          sudo mv runitor /usr/local/bin/
+
       - name: Run strict-syntax pipeline
         run: |
           PIPELINE_FILTER=""
           if [[ -n "${{ inputs.pipelines }}" ]]; then
             PIPELINE_FILTER="--pipelines ${{ inputs.pipelines }}"
           fi
-          uv run nf_core_stats strict-syntax $PIPELINE_FILTER
+          runitor -uuid 4080223c-8257-4e7d-ad2b-c34ef493f42f -- \
+            uv run nf_core_stats strict-syntax $PIPELINE_FILTER

--- a/.github/workflows/lint_strict_syntax.yml
+++ b/.github/workflows/lint_strict_syntax.yml
@@ -34,6 +34,8 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
+      # TODO: Switch to latest release tag instead of HEAD for better caching
+      # Currently HEAD changes frequently, invalidating pipeline-level caching
       - name: Get Nextflow latest commit
         id: nf-commit
         run: |

--- a/.github/workflows/lint_strict_syntax.yml
+++ b/.github/workflows/lint_strict_syntax.yml
@@ -1,0 +1,90 @@
+name: Lint nf-core Pipelines (Strict Syntax)
+
+on:
+  schedule:
+    # Run daily at 1 AM UTC (after other pipelines finish)
+    - cron: "0 1 * * *"
+  workflow_dispatch:
+    inputs:
+      pipelines:
+        description: "Specific pipeline(s) to lint (comma-separated, leave empty for all)"
+        type: string
+        default: ""
+
+permissions:
+  contents: write
+
+env:
+  SOURCES__GITHUB_PIPELINE__GITHUB__API_TOKEN: ${{ secrets.GH_TOKEN_STATS_PAGE }}
+  DESTINATION__MOTHERDUCK__CREDENTIALS__DATABASE: ${{ github.event_name != 'pull_request' && 'nf_core_stats_bot' || '' }}
+  DESTINATION__MOTHERDUCK__CREDENTIALS__PASSWORD: ${{ github.event_name != 'pull_request' && secrets.MOTHERDUCK_TOKEN || '' }}
+  PYTHONUNBUFFERED: "1"
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: pipeline
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Get Nextflow latest commit
+        id: nf-commit
+        run: |
+          COMMIT=$(git ls-remote https://github.com/nextflow-io/nextflow.git HEAD | cut -f1)
+          echo "sha=$COMMIT" >> $GITHUB_OUTPUT
+
+      - name: Restore Nextflow build cache
+        id: cache-nextflow
+        uses: actions/cache/restore@v4
+        with:
+          path: nextflow-src/build/releases
+          key: nextflow-build-${{ steps.nf-commit.outputs.sha }}
+
+      - name: Set up Java
+        if: steps.cache-nextflow.outputs.cache-hit != 'true'
+        uses: actions/setup-java@v4
+        with:
+          distribution: "temurin"
+          java-version: "21"
+
+      - name: Clone and build Nextflow
+        id: build-nextflow
+        if: steps.cache-nextflow.outputs.cache-hit != 'true'
+        run: |
+          cd ..
+          git clone --depth 1 https://github.com/nextflow-io/nextflow.git nextflow-src
+          cd nextflow-src
+          make pack
+          cd build/releases/
+          ln -s nextflow-*-dist nextflow
+
+      - name: Save Nextflow build cache
+        if: steps.cache-nextflow.outputs.cache-hit != 'true' && steps.build-nextflow.outcome == 'success' && always()
+        uses: actions/cache/save@v4
+        with:
+          path: nextflow-src/build/releases
+          key: nextflow-build-${{ steps.nf-commit.outputs.sha }}
+
+      - name: Add Nextflow to PATH
+        run: echo "${{ github.workspace }}/nextflow-src/build/releases" >> $GITHUB_PATH
+
+      - name: Verify Nextflow
+        run: nextflow -version
+
+      - name: Set up uv
+        uses: astral-sh/setup-uv@v5
+        with:
+          python-version: "3.12"
+          enable-cache: true
+
+      - name: Run strict-syntax pipeline
+        run: |
+          PIPELINE_FILTER=""
+          if [[ -n "${{ inputs.pipelines }}" ]]; then
+            PIPELINE_FILTER="--pipelines ${{ inputs.pipelines }}"
+          fi
+          uv run nf_core_stats strict-syntax $PIPELINE_FILTER

--- a/.github/workflows/lint_strict_syntax.yml
+++ b/.github/workflows/lint_strict_syntax.yml
@@ -1,6 +1,9 @@
 name: Lint nf-core Pipelines (Strict Syntax)
 
 on:
+  push:
+    paths:
+      - ".github/workflows/lint_strict_syntax.yml"
   schedule:
     # Run daily at 1 AM UTC (after other pipelines finish)
     - cron: "0 1 * * *"

--- a/.github/workflows/lint_strict_syntax.yml
+++ b/.github/workflows/lint_strict_syntax.yml
@@ -4,8 +4,9 @@ on:
   push:
     paths:
       - ".github/workflows/lint_strict_syntax.yml"
+      - "pipeline/src/nf_core_stats/strict_syntax/**"
+      - "pipeline/src/nf_core_stats/strict_syntax_pipeline.py"
   schedule:
-    # Run daily at 1 AM UTC (after other pipelines finish)
     - cron: "0 1 * * *"
   workflow_dispatch:
     inputs:
@@ -13,19 +14,37 @@ on:
         description: "Specific pipeline(s) to lint (comma-separated, leave empty for all)"
         type: string
         default: ""
-
-permissions:
-  contents: write
+      modules:
+        description: "Specific module(s) to lint (comma-separated, leave empty for all)"
+        type: string
+        default: ""
+      subworkflows:
+        description: "Specific subworkflow(s) to lint (comma-separated, leave empty for all)"
+        type: string
+        default: ""
+      skip_pipelines:
+        description: "Skip linting pipelines"
+        type: boolean
+        default: false
+      skip_modules:
+        description: "Skip linting modules"
+        type: boolean
+        default: false
+      skip_subworkflows:
+        description: "Skip linting subworkflows"
+        type: boolean
+        default: false
 
 env:
   SOURCES__GITHUB_PIPELINE__GITHUB__API_TOKEN: ${{ secrets.GH_TOKEN_STATS_PAGE }}
-  DESTINATION__MOTHERDUCK__CREDENTIALS__DATABASE: ${{ github.event_name != 'pull_request' && 'nf_core_stats_bot' || '' }}
-  DESTINATION__MOTHERDUCK__CREDENTIALS__PASSWORD: ${{ github.event_name != 'pull_request' && secrets.MOTHERDUCK_TOKEN || '' }}
+  DESTINATION__MOTHERDUCK__CREDENTIALS__DATABASE: nf_core_stats_bot
+  DESTINATION__MOTHERDUCK__CREDENTIALS__PASSWORD: ${{ secrets.MOTHERDUCK_TOKEN }}
   PYTHONUNBUFFERED: "1"
 
 jobs:
   lint:
     runs-on: ubuntu-latest
+    timeout-minutes: 180
     defaults:
       run:
         working-directory: pipeline
@@ -34,51 +53,10 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
-      # TODO: Switch to latest release tag instead of HEAD for better caching
-      # Currently HEAD changes frequently, invalidating pipeline-level caching
-      - name: Get Nextflow latest commit
-        id: nf-commit
-        run: |
-          COMMIT=$(git ls-remote https://github.com/nextflow-io/nextflow.git HEAD | cut -f1)
-          echo "sha=$COMMIT" >> $GITHUB_OUTPUT
-
-      - name: Restore Nextflow build cache
-        id: cache-nextflow
-        uses: actions/cache/restore@v4
+      - name: Install Nextflow
+        uses: nf-core/setup-nextflow@b4ec1bc7c16a94435159de94a05253542fddf6ef
         with:
-          path: nextflow-src/build/releases
-          key: nextflow-build-${{ steps.nf-commit.outputs.sha }}
-
-      - name: Set up Java
-        if: steps.cache-nextflow.outputs.cache-hit != 'true'
-        uses: actions/setup-java@v4
-        with:
-          distribution: "temurin"
-          java-version: "21"
-
-      - name: Clone and build Nextflow
-        id: build-nextflow
-        if: steps.cache-nextflow.outputs.cache-hit != 'true'
-        run: |
-          cd ..
-          git clone --depth 1 https://github.com/nextflow-io/nextflow.git nextflow-src
-          cd nextflow-src
-          make pack
-          cd build/releases/
-          ln -s nextflow-*-dist nextflow
-
-      - name: Save Nextflow build cache
-        if: steps.cache-nextflow.outputs.cache-hit != 'true' && steps.build-nextflow.outcome == 'success' && always()
-        uses: actions/cache/save@v4
-        with:
-          path: nextflow-src/build/releases
-          key: nextflow-build-${{ steps.nf-commit.outputs.sha }}
-
-      - name: Add Nextflow to PATH
-        run: echo "${{ github.workspace }}/nextflow-src/build/releases" >> $GITHUB_PATH
-
-      - name: Verify Nextflow
-        run: nextflow -version
+          version: latest-everything
 
       - name: Set up uv
         uses: astral-sh/setup-uv@v5
@@ -98,9 +76,23 @@ jobs:
 
       - name: Run strict-syntax pipeline
         run: |
-          PIPELINE_FILTER=""
+          CMD=(uv run nf_core_stats strict-syntax)
           if [[ -n "${{ inputs.pipelines }}" ]]; then
-            PIPELINE_FILTER="--pipelines ${{ inputs.pipelines }}"
+            CMD+=(--pipelines "${{ inputs.pipelines }}")
           fi
-          runitor -uuid 4080223c-8257-4e7d-ad2b-c34ef493f42f -- \
-            uv run nf_core_stats strict-syntax $PIPELINE_FILTER
+          if [[ -n "${{ inputs.modules }}" ]]; then
+            CMD+=(--modules "${{ inputs.modules }}")
+          fi
+          if [[ -n "${{ inputs.subworkflows }}" ]]; then
+            CMD+=(--subworkflows "${{ inputs.subworkflows }}")
+          fi
+          if [[ "${{ inputs.skip_pipelines }}" == "true" ]]; then
+            CMD+=(--skip-pipelines)
+          fi
+          if [[ "${{ inputs.skip_modules }}" == "true" ]]; then
+            CMD+=(--skip-modules)
+          fi
+          if [[ "${{ inputs.skip_subworkflows }}" == "true" ]]; then
+            CMD+=(--skip-subworkflows)
+          fi
+          runitor -uuid 4080223c-8257-4e7d-ad2b-c34ef493f42f -- "${CMD[@]}"

--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,5 @@ static/data
 *.pyc
 __pycache__
 regulatory
+pipeline/pipelines/
+pipeline/modules/

--- a/config/claude/skills/test-evidence-page/SKILL.md
+++ b/config/claude/skills/test-evidence-page/SKILL.md
@@ -1,0 +1,73 @@
+---
+name: Test Evidence Page
+description: Test Evidence.dev pages with agent-browser
+---
+
+# Test Evidence Page
+
+## When to Use
+- Verifying page renders correctly after changes
+- Checking deploy previews for PR validation
+- Debugging chart/component errors
+
+## Prerequisites
+- `bunx agent-browser` available (no install needed)
+- For local: MotherDuck credentials set
+
+## Testing Deploy Preview
+
+```bash
+# Open page
+bunx agent-browser open "https://deploy-preview-<PR#>--nf-core-stats.netlify.app/<path>/"
+
+# Get accessibility tree (for AI analysis)
+bunx agent-browser snapshot
+
+# Take screenshot
+bunx agent-browser screenshot /tmp/page.png
+
+# Close browser
+bunx agent-browser close
+```
+
+## Testing Local Dev Server
+
+```bash
+# Start server (needs MotherDuck token)
+export MOTHERDUCK_TOKEN="your-token"
+npm run sources
+npm run dev &
+
+# Test page
+bunx agent-browser open "http://localhost:3000/<path>/"
+bunx agent-browser snapshot
+bunx agent-browser screenshot /tmp/local.png
+bunx agent-browser close
+```
+
+## Common Commands
+
+| Command | Description |
+|---------|-------------|
+| `open <url>` | Navigate to URL |
+| `snapshot` | Get accessibility tree |
+| `screenshot <path>` | Save screenshot |
+| `scroll down <px>` | Scroll down |
+| `click <selector>` | Click element |
+| `close` | Close browser |
+
+## Debugging Tips
+
+1. Use `snapshot` to check element presence and text
+2. Screenshot captures visual errors (empty charts, error badges)
+3. Check for "error" text in BigValue components
+4. Verify date columns render correctly in charts
+
+## Example Workflow
+
+```bash
+# Quick visual check
+bunx agent-browser open "https://deploy-preview-111--nf-core-stats.netlify.app/code/strict_syntax/"
+bunx agent-browser screenshot /tmp/check.png
+bunx agent-browser close
+```

--- a/docs/strict_syntax_migration.md
+++ b/docs/strict_syntax_migration.md
@@ -1,0 +1,20 @@
+# Deprecating nf-core/strict-syntax-health
+
+The strict syntax health dashboard has been migrated into [nf-core/stats](https://github.com/nf-core/stats).
+
+## After the stats PR merges
+
+1. Update `README.md` in `nf-core/strict-syntax-health` to point at the live stats dashboard URL (e.g. `https://nf-co.re/stats/code/strict_syntax` or the Netlify deploy URL).
+2. Disable the nightly workflow in `.github/workflows/lint-pipelines.yml` (delete the file or remove the `schedule` trigger).
+3. Archive the repository or add an archive notice in the repo description.
+4. Close open issues with a link to the stats repo and Evidence page.
+
+## Historical data
+
+Historical trend JSON from the old repo can be backfilled into MotherDuck:
+
+```bash
+cd pipeline
+git clone --depth 1 https://github.com/nf-core/strict-syntax-health /tmp/strict-syntax-health
+uv run nf_core_stats strict-syntax --backfill-history /tmp/strict-syntax-health/lint_results --destination motherduck
+```

--- a/pages/code/strict_syntax.md
+++ b/pages/code/strict_syntax.md
@@ -1,0 +1,126 @@
+---
+title: Strict Syntax Health
+sidebar_position: 10
+---
+
+# nf-core Pipeline Strict Syntax Health
+
+This page tracks the adoption of [Nextflow strict syntax](https://www.nextflow.io/docs/latest/strict-syntax.html) across nf-core pipelines. **Fixing all errors from `nextflow lint` will be required by early spring 2026.**
+
+```sql history
+select * from nfcore_db.strict_syntax_history
+```
+
+```sql pipelines
+select * from nfcore_db.strict_syntax_pipelines
+```
+
+## Current Status
+
+<BigValue
+    data={history}
+    value=total_pipelines
+    title="Total Pipelines"
+    sparkline=date
+/>
+<BigValue
+    data={history}
+    value=errors_zero
+    title="Zero Errors"
+    sparkline=date
+/>
+<BigValue
+    data={history}
+    value=parse_errors
+    title="Parse Errors"
+    sparkline=date
+/>
+
+## Error Distribution Over Time
+
+<Tabs>
+    <Tab label="Percentage">
+        <AreaChart
+            data={history}
+            x=date
+            y={['errors_zero_pct', 'errors_low_pct', 'errors_high_pct']}
+            title="Pipeline Error Distribution (%)"
+            yFmt="pct0"
+            yMax={1}
+            seriesColors={['#2ecc71', '#f39c12', '#e74c3c']}
+        />
+    </Tab>
+    <Tab label="Counts">
+        <AreaChart
+            data={history}
+            x=date
+            y={['errors_zero', 'errors_low', 'errors_high']}
+            title="Pipeline Error Distribution"
+            yAxisTitle="Number of Pipelines"
+            seriesColors={['#2ecc71', '#f39c12', '#e74c3c']}
+        />
+    </Tab>
+</Tabs>
+
+## Warning Distribution Over Time
+
+<Tabs>
+    <Tab label="Percentage">
+        <AreaChart
+            data={history}
+            x=date
+            y={['warnings_zero_pct', 'warnings_low_pct', 'warnings_high_pct']}
+            title="Pipeline Warning Distribution (%)"
+            yFmt="pct0"
+            yMax={1}
+            seriesColors={['#1abc9c', '#3498db', '#9b59b6']}
+        />
+    </Tab>
+    <Tab label="Counts">
+        <AreaChart
+            data={history}
+            x=date
+            y={['warnings_zero', 'warnings_low', 'warnings_high']}
+            title="Pipeline Warning Distribution"
+            yAxisTitle="Number of Pipelines"
+            seriesColors={['#1abc9c', '#3498db', '#9b59b6']}
+        />
+    </Tab>
+</Tabs>
+
+## Per-Pipeline Breakdown
+
+<DataTable
+    data={pipelines}
+    search=true
+>
+    <Column id=pipeline_name title="Pipeline" />
+    <Column id=parse_error title="Parse Error" />
+    <Column id=errors title="Errors" contentType=colorscale colorScale=negative />
+    <Column id=warnings title="Warnings" contentType=colorscale colorScale=warning />
+    <Column id=html_url title="Repository" contentType=link linkLabel="View" />
+</DataTable>
+
+## Historical Trend Data
+
+<DataTable
+    data={history}
+    search=false
+    defaultSort={[{ id: 'date', desc: true }]}
+>
+    <Column id=date title="Date" />
+    <Column id=total_pipelines title="Total" />
+    <Column id=parse_errors title="Parse Errors" />
+    <Column id=errors_zero title="0 Errors" contentType=colorscale colorScale=positive />
+    <Column id=errors_low title="1-5 Errors" contentType=colorscale colorScale=warning />
+    <Column id=errors_high title=">5 Errors" contentType=colorscale colorScale=negative />
+</DataTable>
+
+## About
+
+Data sourced from [nf-core/strict-syntax-health](https://github.com/nf-core/strict-syntax-health), which runs `nextflow lint` nightly on all nf-core pipelines.
+
+- **Zero errors**: Pipelines fully compliant with strict syntax
+- **1-5 errors**: Minor issues to fix
+- **>5 errors**: Significant work needed
+- **Parse errors**: Pipelines that couldn't be linted (likely syntax errors)

--- a/pages/code/strict_syntax.md
+++ b/pages/code/strict_syntax.md
@@ -3,45 +3,70 @@ title: Strict Syntax Health
 sidebar_position: 10
 ---
 
-# nf-core Pipeline Strict Syntax Health
+# nf-core Strict Syntax Health
 
-This page tracks the adoption of [Nextflow strict syntax](https://www.nextflow.io/docs/latest/strict-syntax.html) across nf-core pipelines. **Fixing all errors from `nextflow lint` will be required by early spring 2026.**
+This page tracks adoption of [Nextflow strict syntax](https://www.nextflow.io/docs/latest/strict-syntax.html) across nf-core pipelines, modules, and subworkflows. **Fixing all errors from `nextflow lint` will be required by early spring 2026.**
 
-```sql history
+```sql pipeline_history
 select * from nfcore_db.strict_syntax_history
+where component_type = 'pipelines'
+order by date desc
+```
+
+```sql module_history
+select * from nfcore_db.strict_syntax_history
+where component_type = 'modules'
+order by date desc
+```
+
+```sql subworkflow_history
+select * from nfcore_db.strict_syntax_history
+where component_type = 'subworkflows'
+order by date desc
 ```
 
 ```sql pipelines
 select * from nfcore_db.strict_syntax_pipelines
 ```
 
-## Current Status
+```sql modules
+select * from nfcore_db.strict_syntax_modules
+```
+
+```sql subworkflows
+select * from nfcore_db.strict_syntax_subworkflows
+```
+
+<Tabs>
+    <Tab label="Pipelines">
+
+## Pipeline Status
 
 <BigValue
-    data={history}
-    value=total_pipelines
+    data={pipeline_history}
+    value=total
     title="Total Pipelines"
     sparkline=date
 />
 <BigValue
-    data={history}
+    data={pipeline_history}
     value=errors_zero
     title="Zero Errors"
     sparkline=date
 />
 <BigValue
-    data={history}
-    value=parse_errors
-    title="Parse Errors"
+    data={pipeline_history}
+    value=workflow_output_pass
+    title="Workflow Outputs Migrated"
     sparkline=date
 />
 
-## Error Distribution Over Time
+## Pipeline Error Distribution
 
 <Tabs>
     <Tab label="Percentage">
         <AreaChart
-            data={history}
+            data={pipeline_history}
             x=date
             y={['errors_zero_pct', 'errors_low_pct', 'errors_high_pct']}
             title="Pipeline Error Distribution (%)"
@@ -52,7 +77,7 @@ select * from nfcore_db.strict_syntax_pipelines
     </Tab>
     <Tab label="Counts">
         <AreaChart
-            data={history}
+            data={pipeline_history}
             x=date
             y={['errors_zero', 'errors_low', 'errors_high']}
             title="Pipeline Error Distribution"
@@ -62,65 +87,104 @@ select * from nfcore_db.strict_syntax_pipelines
     </Tab>
 </Tabs>
 
-## Warning Distribution Over Time
-
-<Tabs>
-    <Tab label="Percentage">
-        <AreaChart
-            data={history}
-            x=date
-            y={['warnings_zero_pct', 'warnings_low_pct', 'warnings_high_pct']}
-            title="Pipeline Warning Distribution (%)"
-            yFmt="pct0"
-            yMax={1}
-            seriesColors={['#1abc9c', '#3498db', '#9b59b6']}
-        />
-    </Tab>
-    <Tab label="Counts">
-        <AreaChart
-            data={history}
-            x=date
-            y={['warnings_zero', 'warnings_low', 'warnings_high']}
-            title="Pipeline Warning Distribution"
-            yAxisTitle="Number of Pipelines"
-            seriesColors={['#1abc9c', '#3498db', '#9b59b6']}
-        />
-    </Tab>
-</Tabs>
-
 ## Per-Pipeline Breakdown
 
-<DataTable
-    data={pipelines}
-    search=true
->
+<DataTable data={pipelines} search=true>
     <Column id=pipeline_name title="Pipeline" />
+    <Column id=parse_error title="Parse Error" />
+    <Column id=errors title="Errors" contentType=colorscale colorScale=negative />
+    <Column id=warnings title="Warnings" contentType=colorscale colorScale=warning />
+    <Column id=prints_help title="Prints Help" />
+    <Column id=workflow_output_state title="Workflow Outputs" />
+    <Column id=html_url title="Repository" contentType=link linkLabel="View" />
+</DataTable>
+
+    </Tab>
+    <Tab label="Modules">
+
+## Module Status
+
+<BigValue
+    data={module_history}
+    value=total
+    title="Total Modules"
+    sparkline=date
+/>
+<BigValue
+    data={module_history}
+    value=errors_zero
+    title="Zero Errors"
+    sparkline=date
+/>
+
+## Module Error Distribution
+
+<AreaChart
+    data={module_history}
+    x=date
+    y={['errors_zero', 'errors_low', 'errors_high']}
+    title="Module Error Distribution"
+    yAxisTitle="Number of Modules"
+    seriesColors={['#2ecc71', '#f39c12', '#e74c3c']}
+/>
+
+## Per-Module Breakdown
+
+<DataTable data={modules} search=true>
+    <Column id=module_name title="Module" />
     <Column id=parse_error title="Parse Error" />
     <Column id=errors title="Errors" contentType=colorscale colorScale=negative />
     <Column id=warnings title="Warnings" contentType=colorscale colorScale=warning />
     <Column id=html_url title="Repository" contentType=link linkLabel="View" />
 </DataTable>
 
-## Historical Trend Data
+    </Tab>
+    <Tab label="Subworkflows">
 
-<DataTable
-    data={history}
-    search=false
-    defaultSort={[{ id: 'date', desc: true }]}
->
-    <Column id=date title="Date" />
-    <Column id=total_pipelines title="Total" />
-    <Column id=parse_errors title="Parse Errors" />
-    <Column id=errors_zero title="0 Errors" contentType=colorscale colorScale=positive />
-    <Column id=errors_low title="1-5 Errors" contentType=colorscale colorScale=warning />
-    <Column id=errors_high title=">5 Errors" contentType=colorscale colorScale=negative />
+## Subworkflow Status
+
+<BigValue
+    data={subworkflow_history}
+    value=total
+    title="Total Subworkflows"
+    sparkline=date
+/>
+<BigValue
+    data={subworkflow_history}
+    value=errors_zero
+    title="Zero Errors"
+    sparkline=date
+/>
+
+## Subworkflow Error Distribution
+
+<AreaChart
+    data={subworkflow_history}
+    x=date
+    y={['errors_zero', 'errors_low', 'errors_high']}
+    title="Subworkflow Error Distribution"
+    yAxisTitle="Number of Subworkflows"
+    seriesColors={['#2ecc71', '#f39c12', '#e74c3c']}
+/>
+
+## Per-Subworkflow Breakdown
+
+<DataTable data={subworkflows} search=true>
+    <Column id=subworkflow_name title="Subworkflow" />
+    <Column id=parse_error title="Parse Error" />
+    <Column id=errors title="Errors" contentType=colorscale colorScale=negative />
+    <Column id=warnings title="Warnings" contentType=colorscale colorScale=warning />
+    <Column id=html_url title="Repository" contentType=link linkLabel="View" />
 </DataTable>
+
+    </Tab>
+</Tabs>
 
 ## About
 
-Data sourced from [nf-core/strict-syntax-health](https://github.com/nf-core/strict-syntax-health), which runs `nextflow lint` nightly on all nf-core pipelines.
+Nightly `nextflow lint` runs via the stats repo pipeline (migrated from [nf-core/strict-syntax-health](https://github.com/nf-core/strict-syntax-health)).
 
-- **Zero errors**: Pipelines fully compliant with strict syntax
+- **Zero errors**: Fully compliant with strict syntax
 - **1-5 errors**: Minor issues to fix
 - **>5 errors**: Significant work needed
-- **Parse errors**: Pipelines that couldn't be linted (likely syntax errors)
+- **Workflow outputs**: Migration from `publishDir` to the new `output {}` block

--- a/pipeline/pyproject.toml
+++ b/pipeline/pyproject.toml
@@ -10,6 +10,7 @@ authors = [{ name = "nf-core team" }]
 dependencies = [
     "cyclopts>=4.1.0",
     "dlt[cli,duckdb,motherduck]>=1.18.2",
+    "httpx>=0.27.0",
     "python-dotenv==1.2.2",
     "requests>=2.31.0",
     "semanticscholar>=0.11.0",

--- a/pipeline/src/nf_core_stats/__init__.py
+++ b/pipeline/src/nf_core_stats/__init__.py
@@ -3,7 +3,7 @@ from importlib.metadata import version
 from cyclopts import App
 from dotenv import load_dotenv
 
-from . import citations_pipeline, github_pipeline, slack_pipeline
+from . import citations_pipeline, github_pipeline, slack_pipeline, strict_syntax_pipeline
 
 __version__ = version("nf_core_stats")
 
@@ -14,6 +14,7 @@ app = App()
 app.command(github_pipeline.main, "github")
 app.command(slack_pipeline.main, "slack")
 app.command(citations_pipeline.main, "citations")
+app.command(strict_syntax_pipeline.main, "strict-syntax")
 
 
 if __name__ == "__main__":

--- a/pipeline/src/nf_core_stats/strict_syntax/__init__.py
+++ b/pipeline/src/nf_core_stats/strict_syntax/__init__.py
@@ -1,0 +1,12 @@
+"""Nextflow strict syntax linting for nf-core pipelines, modules, and subworkflows."""
+
+from .history import create_history_entry
+from .modules import lint_modules, lint_subworkflows
+from .pipelines import lint_pipelines
+
+__all__ = [
+    "create_history_entry",
+    "lint_modules",
+    "lint_pipelines",
+    "lint_subworkflows",
+]

--- a/pipeline/src/nf_core_stats/strict_syntax/backfill.py
+++ b/pipeline/src/nf_core_stats/strict_syntax/backfill.py
@@ -1,0 +1,48 @@
+"""Backfill historical strict syntax data from strict-syntax-health JSON files."""
+
+import json
+from pathlib import Path
+
+
+def load_history_backfill(lint_results_dir: str) -> list[dict]:
+    """Load history JSON files exported from nf-core/strict-syntax-health."""
+    base = Path(lint_results_dir)
+    rows: list[dict] = []
+
+    mapping = {
+        "pipelines_history.json": "pipelines",
+        "modules_history.json": "modules",
+        "subworkflows_history.json": "subworkflows",
+    }
+
+    for filename, component_type in mapping.items():
+        path = base / filename
+        if not path.exists():
+            continue
+        history = json.loads(path.read_text())
+        for entry in history:
+            rows.append(
+                {
+                    "date": entry["date"],
+                    "component_type": component_type,
+                    "nextflow_version": entry.get("nextflow_version", "unknown"),
+                    "nextflow_sha": entry.get("nextflow_sha", "unknown"),
+                    "total": entry["total"],
+                    "parse_errors": entry["parse_errors"],
+                    "errors_zero": entry["errors_zero"],
+                    "errors_low": entry["errors_low"],
+                    "errors_high": entry["errors_high"],
+                    "warnings_zero": entry["warnings_zero"],
+                    "warnings_low": entry["warnings_low"],
+                    "warnings_high": entry["warnings_high"],
+                    "total_errors": entry.get("total_errors"),
+                    "total_warnings": entry.get("total_warnings"),
+                    "prints_help_pass": entry.get("prints_help_pass"),
+                    "prints_help_fail": entry.get("prints_help_fail"),
+                    "workflow_output_pass": entry.get("workflow_output_pass"),
+                    "workflow_output_warn": entry.get("workflow_output_warn"),
+                    "workflow_output_error": entry.get("workflow_output_error"),
+                }
+            )
+
+    return rows

--- a/pipeline/src/nf_core_stats/strict_syntax/fetch.py
+++ b/pipeline/src/nf_core_stats/strict_syntax/fetch.py
@@ -1,0 +1,27 @@
+import httpx
+
+from .._logging import logger
+from .paths import PIPELINES_URL
+
+
+def fetch_pipelines() -> list[dict]:
+    """Fetch active nf-core pipelines from nf-co.re."""
+    logger.info("Fetching pipelines from %s", PIPELINES_URL)
+    response = httpx.get(PIPELINES_URL, timeout=60)
+    response.raise_for_status()
+    data = response.json()
+
+    pipelines = []
+    for pipeline in data.get("remote_workflows", []):
+        if pipeline.get("archived", False):
+            continue
+        pipelines.append(
+            {
+                "name": pipeline["name"],
+                "full_name": pipeline["full_name"],
+                "html_url": f"https://github.com/{pipeline['full_name']}",
+            }
+        )
+
+    logger.info("Found %d active pipelines", len(pipelines))
+    return pipelines

--- a/pipeline/src/nf_core_stats/strict_syntax/git_utils.py
+++ b/pipeline/src/nf_core_stats/strict_syntax/git_utils.py
@@ -1,0 +1,71 @@
+import subprocess
+from pathlib import Path
+
+from .._logging import logger
+from .paths import MODULES_REPO_URL
+
+
+def get_remote_commit_hash(repo_url: str, branch: str = "HEAD") -> str | None:
+    """Get the latest commit hash from a remote repository without cloning."""
+    try:
+        result = subprocess.run(
+            ["git", "ls-remote", repo_url, branch],
+            capture_output=True,
+            text=True,
+            check=True,
+            timeout=30,
+        )
+        if result.stdout.strip():
+            return result.stdout.split()[0]
+        return None
+    except (subprocess.CalledProcessError, subprocess.TimeoutExpired):
+        return None
+
+
+def get_local_commit_hash(repo_path: Path) -> str:
+    result = subprocess.run(
+        ["git", "-C", str(repo_path), "rev-parse", "HEAD"],
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    return result.stdout.strip()
+
+
+def get_remote_head_sha(repo_url: str) -> str | None:
+    """Prefer dev branch, fall back to default branch HEAD."""
+    sha = get_remote_commit_hash(repo_url, "refs/heads/dev")
+    if sha:
+        return sha
+    return get_remote_commit_hash(repo_url, "HEAD")
+
+
+def clone_modules_repo(modules_dir: Path) -> str:
+    if modules_dir.exists():
+        logger.info("Updating nf-core/modules repository...")
+        subprocess.run(
+            ["git", "-C", str(modules_dir), "fetch", "--quiet", "origin", "master"],
+            check=True,
+            capture_output=True,
+        )
+        subprocess.run(
+            ["git", "-C", str(modules_dir), "checkout", "--quiet", "master"],
+            check=True,
+            capture_output=True,
+        )
+        subprocess.run(
+            ["git", "-C", str(modules_dir), "pull", "--quiet"],
+            check=True,
+            capture_output=True,
+        )
+    else:
+        logger.info("Cloning nf-core/modules repository...")
+        subprocess.run(
+            ["git", "clone", "--quiet", "--depth", "1", MODULES_REPO_URL, str(modules_dir)],
+            check=True,
+            capture_output=True,
+        )
+
+    commit_hash = get_local_commit_hash(modules_dir)
+    logger.info("nf-core/modules ready at %s (%s)", modules_dir, commit_hash[:8])
+    return commit_hash

--- a/pipeline/src/nf_core_stats/strict_syntax/history.py
+++ b/pipeline/src/nf_core_stats/strict_syntax/history.py
@@ -1,0 +1,48 @@
+from .._logging import logger
+
+
+def create_history_entry(results: list[dict], *, include_prints_help: bool = False) -> dict:
+    """Create a daily aggregated history entry from a full result snapshot."""
+    valid_results = [row for row in results if not row.get("parse_error", False)]
+    parse_error_results = [row for row in results if row.get("parse_error", False)]
+
+    entry = {
+        "total": len(results),
+        "parse_errors": len(parse_error_results),
+        "errors_zero": sum(1 for row in valid_results if row["errors"] == 0),
+        "errors_low": sum(1 for row in valid_results if 0 < row["errors"] <= 5),
+        "errors_high": sum(1 for row in valid_results if row["errors"] > 5),
+        "warnings_zero": sum(1 for row in valid_results if row["warnings"] == 0),
+        "warnings_low": sum(1 for row in valid_results if 0 < row["warnings"] <= 20),
+        "warnings_high": sum(1 for row in valid_results if row["warnings"] > 20),
+        "total_errors": sum(row["errors"] for row in valid_results),
+        "total_warnings": sum(row["warnings"] for row in valid_results),
+    }
+
+    if include_prints_help:
+        entry["prints_help_pass"] = sum(1 for row in valid_results if row.get("prints_help") is True)
+        entry["prints_help_fail"] = sum(1 for row in valid_results if row.get("prints_help") is False)
+
+        from .lint import workflow_output_state
+
+        states = [workflow_output_state(row) for row in results]
+        entry["workflow_output_pass"] = sum(1 for state in states if state == "pass")
+        entry["workflow_output_warn"] = sum(1 for state in states if state == "warn")
+        entry["workflow_output_error"] = sum(1 for state in states if state == "error")
+
+    return entry
+
+
+def merge_snapshot(existing: dict[str, dict], updates: list[dict], *, name_key: str = "name") -> dict[str, dict]:
+    """Merge lint results into a name-keyed snapshot dict."""
+    merged = dict(existing)
+    for row in updates:
+        name = row[name_key]
+        merged[name] = {key: value for key, value in row.items() if key != name_key}
+        merged[name]["name"] = name
+    logger.info("Snapshot size after merge: %d", len(merged))
+    return merged
+
+
+def snapshot_to_list(snapshot: dict[str, dict]) -> list[dict]:
+    return list(snapshot.values())

--- a/pipeline/src/nf_core_stats/strict_syntax/lint.py
+++ b/pipeline/src/nf_core_stats/strict_syntax/lint.py
@@ -1,0 +1,206 @@
+import json
+import os
+import re
+import subprocess
+from datetime import datetime, timezone
+from pathlib import Path
+
+from .._logging import logger
+
+WORKFLOW_OUTPUT_RE = re.compile(r"^output\s*\{", re.MULTILINE)
+PUBLISHDIR_RE = re.compile(r"\bpublishDir\b")
+_MAX_REPORT_MATCHES = 200
+
+
+def _scan_lines(repo_path: Path, patterns: tuple[str, ...], regex: re.Pattern) -> list[tuple[str, int, str]]:
+    matches: list[tuple[str, int, str]] = []
+    seen: set[Path] = set()
+    for pattern in patterns:
+        for src_file in repo_path.rglob(pattern):
+            if src_file in seen:
+                continue
+            seen.add(src_file)
+            try:
+                source_lines = src_file.read_text().splitlines()
+            except (OSError, UnicodeDecodeError):
+                continue
+            rel = str(src_file.relative_to(repo_path))
+            for line_num, line in enumerate(source_lines, start=1):
+                if regex.search(line):
+                    matches.append((rel, line_num, line.strip()))
+    matches.sort(key=lambda item: (item[0], item[1]))
+    return matches
+
+
+def detect_workflow_output(repo_path: Path) -> bool:
+    return bool(_scan_lines(repo_path, ("*.nf",), WORKFLOW_OUTPUT_RE))
+
+
+def detect_publishdir(repo_path: Path) -> bool:
+    return bool(_scan_lines(repo_path, ("*.nf", "*.config"), PUBLISHDIR_RE))
+
+
+def workflow_output_state(result: dict) -> str | None:
+    has_output = result.get("workflow_output")
+    has_publishdir = result.get("publishdir")
+    if has_output is None or has_publishdir is None:
+        return None
+    if has_output and has_publishdir:
+        return "warn"
+    if has_output:
+        return "pass"
+    return "error"
+
+
+def lint_component(repo_path: Path, target_path: Path | None = None) -> dict:
+    if target_path:
+        try:
+            relative_path = target_path.relative_to(repo_path)
+        except ValueError:
+            relative_path = target_path
+        cmd = ["nextflow", "lint", str(relative_path), "-o", "json"]
+    else:
+        cmd = ["nextflow", "lint", ".", "-o", "json"]
+
+    result = subprocess.run(cmd, cwd=repo_path, capture_output=True, text=True)
+
+    try:
+        lint_result = json.loads(result.stdout)
+        lint_result["parse_error"] = False
+        return lint_result
+    except json.JSONDecodeError:
+        name = target_path.name if target_path else repo_path.name
+        logger.warning("Failed to parse lint output for %s", name)
+        return {"summary": {"errors": 0}, "errors": [], "warnings": [], "parse_error": True}
+
+
+def lint_directory_bulk(repo_path: Path, target_path: Path) -> dict:
+    try:
+        relative_path = target_path.relative_to(repo_path)
+    except ValueError:
+        relative_path = target_path
+
+    result = subprocess.run(
+        ["nextflow", "lint", str(relative_path), "-o", "json"],
+        cwd=repo_path,
+        capture_output=True,
+        text=True,
+    )
+
+    try:
+        return json.loads(result.stdout)
+    except json.JSONDecodeError:
+        logger.warning("Failed to parse bulk lint output for %s", target_path)
+        return {"errors": [], "warnings": []}
+
+
+def _extract_component_name_from_path(filepath: str, component_type: str) -> str | None:
+    parts = Path(filepath).parts
+    try:
+        nf_core_idx = parts.index("nf-core")
+    except ValueError:
+        return None
+
+    if component_type == "modules":
+        if len(parts) > nf_core_idx + 2:
+            return f"{parts[nf_core_idx + 1]}_{parts[nf_core_idx + 2]}"
+    elif len(parts) > nf_core_idx + 1:
+        return parts[nf_core_idx + 1]
+    return None
+
+
+def group_lint_results_by_component(lint_result: dict, component_type: str) -> dict[str, dict]:
+    grouped: dict[str, dict] = {}
+    for issue_type in ("errors", "warnings"):
+        for issue in lint_result.get(issue_type, []):
+            filename = issue.get("filename", "")
+            name = _extract_component_name_from_path(filename, component_type)
+            if not name:
+                continue
+            grouped.setdefault(name, {"errors": [], "warnings": []})
+            grouped[name][issue_type].append(issue)
+    return grouped
+
+
+def _get_code_snippet(repo_path: Path, filename: str, line_num: int, column: int) -> str | None:
+    try:
+        file_path = repo_path / filename
+        if not file_path.exists():
+            return None
+        source_lines = file_path.read_text().splitlines()
+        if line_num < 1 or line_num > len(source_lines):
+            return None
+        source_line = source_lines[line_num - 1]
+        caret_line = " " * (column - 1) + "^" * max(1, min(10, len(source_line) - column + 1))
+        return f"    ```nextflow\n    {source_line}\n    {caret_line}\n    ```"
+    except OSError:
+        return None
+
+
+def generate_markdown_from_issues(
+    errors: list[dict],
+    warnings: list[dict],
+    nextflow_version: str,
+    repo_path: Path | None = None,
+) -> str:
+    now = datetime.now(timezone.utc).isoformat()
+    error_count = len(errors)
+    warning_count = len(warnings)
+
+    lines = [
+        "# Nextflow lint results",
+        "",
+        f"- Generated: {now}",
+        f"- Nextflow version: {nextflow_version}",
+    ]
+
+    if error_count == 0 and warning_count == 0:
+        lines.append("- Summary: No issues found")
+        return "\n".join(lines)
+
+    summary_parts = []
+    if error_count:
+        summary_parts.append(f"{error_count} error{'s' if error_count != 1 else ''}")
+    if warning_count:
+        summary_parts.append(f"{warning_count} warning{'s' if warning_count != 1 else ''}")
+    lines.append(f"- Summary: {', '.join(summary_parts)}")
+
+    for section_title, issues in (("Errors", errors), ("Warnings", warnings)):
+        if not issues:
+            continue
+        icon = ":x:" if section_title == "Errors" else ":warning:"
+        lines.extend(["", f"## {icon} {section_title}", ""])
+        for issue in issues:
+            filename = issue.get("filename", "unknown")
+            line_num = issue.get("startLine", 0)
+            col = issue.get("startColumn", 0)
+            message = issue.get("message", "")
+            label = section_title[:-1]
+            lines.append(f"- {label}: `{filename}:{line_num}:{col}`: {message}")
+            lines.append("")
+            if repo_path:
+                snippet = _get_code_snippet(repo_path, filename, line_num, col)
+                if snippet:
+                    lines.extend([snippet, ""])
+
+    return "\n".join(lines)
+
+
+def test_prints_help(repo_path: Path) -> tuple[bool, str]:
+    try:
+        env = {**os.environ, "NXF_SYNTAX_PARSER": "v2"}
+        result = subprocess.run(
+            ["nextflow", "run", ".", "--help"],
+            cwd=repo_path,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.STDOUT,
+            text=True,
+            timeout=120,
+            env=env,
+        )
+        output = f"$ NXF_SYNTAX_PARSER=v2 nextflow run . --help\n\n{result.stdout}"
+        return result.returncode == 0, output
+    except subprocess.TimeoutExpired:
+        return False, "$ NXF_SYNTAX_PARSER=v2 nextflow run . --help\n\nError: Timeout after 120s\n"
+    except OSError as exc:
+        return False, f"$ NXF_SYNTAX_PARSER=v2 nextflow run . --help\n\nError: {exc}\n"

--- a/pipeline/src/nf_core_stats/strict_syntax/modules.py
+++ b/pipeline/src/nf_core_stats/strict_syntax/modules.py
@@ -1,0 +1,219 @@
+from pathlib import Path
+
+from .._logging import logger
+from .git_utils import clone_modules_repo, get_remote_commit_hash
+from .lint import generate_markdown_from_issues, group_lint_results_by_component, lint_component, lint_directory_bulk
+from .paths import MODULES_DIR
+
+
+def discover_modules(modules_dir: Path = MODULES_DIR) -> list[dict]:
+    modules_path = modules_dir / "modules" / "nf-core"
+    if not modules_path.exists():
+        logger.warning("Modules path not found: %s", modules_path)
+        return []
+
+    modules = []
+    for tool_dir in sorted(modules_path.iterdir()):
+        if not tool_dir.is_dir() or tool_dir.name.startswith("."):
+            continue
+        if (tool_dir / "main.nf").exists():
+            component_dirs = [(tool_dir, tool_dir.name)]
+        else:
+            component_dirs = []
+            for subcommand_dir in sorted(tool_dir.iterdir()):
+                if not subcommand_dir.is_dir() or subcommand_dir.name.startswith("."):
+                    continue
+                if (subcommand_dir / "main.nf").exists():
+                    component_dirs.append((subcommand_dir, f"{tool_dir.name}_{subcommand_dir.name}"))
+        for path, name in component_dirs:
+            modules.append(
+                {
+                    "name": name,
+                    "path": path,
+                    "html_url": (
+                        f"https://github.com/nf-core/modules/tree/master/modules/nf-core/"
+                        f"{path.relative_to(modules_path)}"
+                    ),
+                }
+            )
+
+    logger.info("Found %d modules", len(modules))
+    return modules
+
+
+def discover_subworkflows(modules_dir: Path = MODULES_DIR) -> list[dict]:
+    subworkflows_path = modules_dir / "subworkflows" / "nf-core"
+    if not subworkflows_path.exists():
+        logger.warning("Subworkflows path not found: %s", subworkflows_path)
+        return []
+
+    subworkflows = []
+    for subworkflow_dir in sorted(subworkflows_path.iterdir()):
+        if not subworkflow_dir.is_dir() or subworkflow_dir.name.startswith("."):
+            continue
+        if (subworkflow_dir / "main.nf").exists():
+            subworkflows.append(
+                {
+                    "name": subworkflow_dir.name,
+                    "path": subworkflow_dir,
+                    "html_url": (
+                        f"https://github.com/nf-core/modules/tree/master/subworkflows/nf-core/{subworkflow_dir.name}"
+                    ),
+                }
+            )
+
+    logger.info("Found %d subworkflows", len(subworkflows))
+    return subworkflows
+
+
+def _lint_components_individual(
+    items: list[dict],
+    *,
+    component_type: str,
+    nextflow_version: str,
+    modules_dir: Path,
+) -> list[dict]:
+    results = []
+    for item in items:
+        logger.info("Linting %s %s...", component_type[:-1], item["name"])
+        try:
+            lint_result = lint_component(modules_dir, item["path"])
+            lint_output = generate_markdown_from_issues(
+                lint_result.get("errors", []),
+                lint_result.get("warnings", []),
+                nextflow_version,
+                modules_dir,
+            )
+            results.append(
+                {
+                    "name": item["name"],
+                    "html_url": item["html_url"],
+                    "errors": lint_result.get("summary", {}).get("errors", 0),
+                    "warnings": len(lint_result.get("warnings", [])),
+                    "parse_error": lint_result.get("parse_error", False),
+                    "lint_output": lint_output,
+                }
+            )
+        except OSError as exc:
+            logger.error("Failed to lint %s: %s", item["name"], exc)
+            results.append(
+                {
+                    "name": item["name"],
+                    "html_url": item["html_url"],
+                    "errors": 0,
+                    "warnings": 0,
+                    "parse_error": True,
+                    "lint_output": None,
+                }
+            )
+    return results
+
+
+def _lint_components_bulk(
+    items: list[dict],
+    *,
+    component_type: str,
+    target_path: Path,
+    nextflow_version: str,
+    modules_dir: Path,
+) -> list[dict]:
+    logger.info("Running bulk lint on %d %s...", len(items), component_type)
+    bulk_result = lint_directory_bulk(modules_dir, target_path)
+    grouped = group_lint_results_by_component(bulk_result, component_type)
+
+    results = []
+    for item in items:
+        component_issues = grouped.get(item["name"], {"errors": [], "warnings": []})
+        errors = component_issues["errors"]
+        warnings = component_issues["warnings"]
+        lint_output = generate_markdown_from_issues(errors, warnings, nextflow_version, modules_dir)
+        results.append(
+            {
+                "name": item["name"],
+                "html_url": item["html_url"],
+                "errors": len(errors),
+                "warnings": len(warnings),
+                "parse_error": False,
+                "lint_output": lint_output,
+            }
+        )
+    return results
+
+
+def lint_modules(
+    modules: list[dict],
+    *,
+    snapshot: dict[str, dict],
+    nextflow_version: str,
+    no_cache: bool = False,
+    modules_dir: Path = MODULES_DIR,
+) -> tuple[list[dict], dict[str, dict]]:
+    if len(modules) <= 5:
+        results = _lint_components_individual(
+            modules,
+            component_type="modules",
+            nextflow_version=nextflow_version,
+            modules_dir=modules_dir,
+        )
+    else:
+        results = _lint_components_bulk(
+            modules,
+            component_type="modules",
+            target_path=modules_dir / "modules" / "nf-core",
+            nextflow_version=nextflow_version,
+            modules_dir=modules_dir,
+        )
+
+    updated = {row["name"]: {key: value for key, value in row.items() if key != "name"} for row in results}
+    return results, updated
+
+
+def lint_subworkflows(
+    subworkflows: list[dict],
+    *,
+    snapshot: dict[str, dict],
+    nextflow_version: str,
+    no_cache: bool = False,
+    modules_dir: Path = MODULES_DIR,
+) -> tuple[list[dict], dict[str, dict]]:
+    if len(subworkflows) <= 5:
+        results = _lint_components_individual(
+            subworkflows,
+            component_type="subworkflows",
+            nextflow_version=nextflow_version,
+            modules_dir=modules_dir,
+        )
+    else:
+        results = _lint_components_bulk(
+            subworkflows,
+            component_type="subworkflows",
+            target_path=modules_dir / "subworkflows" / "nf-core",
+            nextflow_version=nextflow_version,
+            modules_dir=modules_dir,
+        )
+
+    updated = {row["name"]: {key: value for key, value in row.items() if key != "name"} for row in results}
+    return results, updated
+
+
+def prepare_modules_repo(
+    *,
+    snapshot: dict[str, dict],
+    no_cache: bool,
+    check_modules: bool,
+    check_subworkflows: bool,
+    modules_dir: Path = MODULES_DIR,
+) -> tuple[bool, str | None]:
+    """Return (unchanged, remote_commit). Clone/update repo when changed."""
+    remote_commit = get_remote_commit_hash("https://github.com/nf-core/modules.git", "refs/heads/master")
+    if remote_commit is None:
+        clone_modules_repo(modules_dir)
+        return False, get_remote_commit_hash("https://github.com/nf-core/modules.git", "refs/heads/master")
+
+    stored_commit = snapshot.get("_repo_commit")
+    if not no_cache and stored_commit == remote_commit and (snapshot.get("modules") or snapshot.get("subworkflows")):
+        logger.info("nf-core/modules unchanged at %s", remote_commit[:8])
+        return True, remote_commit
+
+    clone_modules_repo(modules_dir)
+    return False, remote_commit

--- a/pipeline/src/nf_core_stats/strict_syntax/nextflow.py
+++ b/pipeline/src/nf_core_stats/strict_syntax/nextflow.py
@@ -1,0 +1,28 @@
+import subprocess
+
+from .._logging import logger
+from .paths import NEXTFLOW_REPO
+
+
+def get_nextflow_sha() -> str:
+    result = subprocess.run(
+        ["git", "ls-remote", NEXTFLOW_REPO, "HEAD"],
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    return result.stdout.split()[0]
+
+
+def get_nextflow_version() -> str:
+    try:
+        result = subprocess.run(["nextflow", "-version"], capture_output=True, text=True, check=False)
+        for line in result.stdout.split("\n"):
+            if "version" in line.lower():
+                parts = line.split()
+                for index, part in enumerate(parts):
+                    if part.lower() == "version" and index + 1 < len(parts):
+                        return parts[index + 1]
+    except FileNotFoundError:
+        logger.warning("Nextflow not found in PATH")
+    return "unknown"

--- a/pipeline/src/nf_core_stats/strict_syntax/paths.py
+++ b/pipeline/src/nf_core_stats/strict_syntax/paths.py
@@ -1,0 +1,8 @@
+from pathlib import Path
+
+PIPELINES_URL = "https://nf-co.re/pipelines.json"
+MODULES_REPO_URL = "https://github.com/nf-core/modules.git"
+NEXTFLOW_REPO = "https://github.com/nextflow-io/nextflow.git"
+
+PIPELINES_DIR = Path("pipelines")
+MODULES_DIR = Path("modules")

--- a/pipeline/src/nf_core_stats/strict_syntax/pipelines.py
+++ b/pipeline/src/nf_core_stats/strict_syntax/pipelines.py
@@ -1,0 +1,175 @@
+import subprocess
+from pathlib import Path
+
+from .._logging import logger
+from .git_utils import get_local_commit_hash, get_remote_head_sha
+from .lint import (
+    detect_publishdir,
+    detect_workflow_output,
+    generate_markdown_from_issues,
+    lint_component,
+    test_prints_help,
+)
+from .paths import PIPELINES_DIR
+
+
+def clone_pipeline(pipeline: dict, pipelines_dir: Path = PIPELINES_DIR) -> Path:
+    repo_path = pipelines_dir / pipeline["name"]
+
+    if repo_path.exists():
+        try:
+            subprocess.run(
+                ["git", "-C", str(repo_path), "fetch", "--quiet", "origin", "dev"],
+                check=True,
+                capture_output=True,
+            )
+            subprocess.run(
+                ["git", "-C", str(repo_path), "checkout", "--quiet", "dev"],
+                check=True,
+                capture_output=True,
+            )
+        except subprocess.CalledProcessError:
+            pass
+        subprocess.run(
+            ["git", "-C", str(repo_path), "pull", "--quiet"],
+            check=True,
+            capture_output=True,
+        )
+    else:
+        logger.info("Cloning %s...", pipeline["full_name"])
+        pipelines_dir.mkdir(parents=True, exist_ok=True)
+        try:
+            subprocess.run(
+                ["git", "clone", "--quiet", "--depth", "1", "--branch", "dev", pipeline["html_url"], str(repo_path)],
+                check=True,
+                capture_output=True,
+            )
+        except subprocess.CalledProcessError:
+            subprocess.run(
+                ["git", "clone", "--quiet", "--depth", "1", pipeline["html_url"], str(repo_path)],
+                check=True,
+                capture_output=True,
+            )
+
+    return repo_path
+
+
+def _cached_pipeline_row(pipeline: dict, cached: dict, commit: str) -> dict:
+    return {
+        "name": pipeline["name"],
+        "full_name": pipeline["full_name"],
+        "html_url": pipeline["html_url"],
+        "commit_sha": commit,
+        "errors": cached["errors"],
+        "warnings": cached["warnings"],
+        "parse_error": cached.get("parse_error", False),
+        "prints_help": cached.get("prints_help"),
+        "workflow_output": cached.get("workflow_output"),
+        "publishdir": cached.get("publishdir"),
+        "lint_output": cached.get("lint_output"),
+    }
+
+
+def _needs_reprocess(cached: dict) -> bool:
+    needs_prints_help = (
+        cached.get("errors", 0) == 0
+        and not cached.get("parse_error", False)
+        and cached.get("prints_help") is None
+    )
+    needs_output_detection = cached.get("workflow_output") is None or cached.get("publishdir") is None
+    return needs_prints_help or needs_output_detection
+
+
+def lint_pipelines(
+    pipelines: list[dict],
+    *,
+    snapshot: dict[str, dict],
+    nextflow_version: str,
+    no_cache: bool = False,
+) -> tuple[list[dict], dict[str, dict]]:
+    """Lint pipelines, reusing snapshot entries when remote commit is unchanged."""
+    updated_snapshot = dict(snapshot)
+    results: list[dict] = []
+    skipped = 0
+    linted = 0
+
+    for pipeline in pipelines:
+        name = pipeline["name"]
+        cached = updated_snapshot.get(name)
+        remote_commit = get_remote_head_sha(pipeline["html_url"])
+
+        if (
+            not no_cache
+            and cached
+            and remote_commit
+            and remote_commit == cached.get("commit_sha")
+            and not _needs_reprocess(cached)
+        ):
+            row = _cached_pipeline_row(pipeline, cached, remote_commit)
+            results.append(row)
+            skipped += 1
+            continue
+
+        logger.info("Linting pipeline %s...", name)
+        try:
+            repo_path = clone_pipeline(pipeline)
+            commit_hash = get_local_commit_hash(repo_path)
+            lint_result = lint_component(repo_path)
+            error_count = lint_result.get("summary", {}).get("errors", 0)
+            warning_count = len(lint_result.get("warnings", []))
+            parse_error = lint_result.get("parse_error", False)
+            workflow_output = detect_workflow_output(repo_path)
+            publishdir = detect_publishdir(repo_path)
+
+            prints_help = None
+            help_output = None
+            if not parse_error and error_count == 0:
+                prints_help, help_output = test_prints_help(repo_path)
+
+            lint_output = None
+            if not parse_error:
+                lint_output = generate_markdown_from_issues(
+                    lint_result.get("errors", []),
+                    lint_result.get("warnings", []),
+                    nextflow_version,
+                    repo_path,
+                )
+
+            row = {
+                "name": name,
+                "full_name": pipeline["full_name"],
+                "html_url": pipeline["html_url"],
+                "commit_sha": commit_hash,
+                "errors": error_count,
+                "warnings": warning_count,
+                "parse_error": parse_error,
+                "prints_help": prints_help,
+                "workflow_output": workflow_output,
+                "publishdir": publishdir,
+                "lint_output": lint_output,
+                "help_output": help_output,
+            }
+            linted += 1
+        except subprocess.CalledProcessError as exc:
+            logger.error("Failed to process %s: %s", name, exc)
+            row = {
+                "name": name,
+                "full_name": pipeline["full_name"],
+                "html_url": pipeline["html_url"],
+                "commit_sha": remote_commit,
+                "errors": 0,
+                "warnings": 0,
+                "parse_error": True,
+                "prints_help": None,
+                "workflow_output": None,
+                "publishdir": None,
+                "lint_output": None,
+                "help_output": None,
+            }
+            linted += 1
+
+        updated_snapshot[name] = {key: value for key, value in row.items() if key != "name"}
+        results.append(row)
+
+    logger.info("Pipelines: skipped %d unchanged, linted %d", skipped, linted)
+    return results, updated_snapshot

--- a/pipeline/src/nf_core_stats/strict_syntax_pipeline.py
+++ b/pipeline/src/nf_core_stats/strict_syntax_pipeline.py
@@ -1,0 +1,237 @@
+"""DLT pipeline for strict-syntax linting of nf-core pipelines.
+
+This pipeline:
+1. Fetches the list of nf-core pipelines from nf-co.re
+2. Clones each pipeline and runs `nextflow lint`
+3. Stores results in MotherDuck for visualization in Evidence.dev
+"""
+
+import json
+import subprocess
+from collections.abc import Iterator
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Annotated
+
+import dlt
+import httpx
+
+from ._logging import log_pipeline_stats, logger
+
+PIPELINES_URL = "https://nf-co.re/pipelines.json"
+PIPELINES_DIR = Path("pipelines")
+
+
+def get_nextflow_version() -> str:
+    """Get the current nextflow version."""
+    try:
+        result = subprocess.run(["nextflow", "-version"], capture_output=True, text=True, check=False)
+        for line in result.stdout.split("\n"):
+            if "version" in line.lower():
+                parts = line.split()
+                for i, part in enumerate(parts):
+                    if part.lower() == "version" and i + 1 < len(parts):
+                        return parts[i + 1]
+    except FileNotFoundError:
+        logger.warning("Nextflow not found in PATH")
+    return "unknown"
+
+
+def fetch_pipelines() -> list[dict]:
+    """Fetch pipeline list from nf-co.re."""
+    logger.info(f"Fetching pipelines from {PIPELINES_URL}")
+    response = httpx.get(PIPELINES_URL, timeout=60)
+    response.raise_for_status()
+    data = response.json()
+
+    pipelines = []
+    for pipeline in data.get("remote_workflows", []):
+        if pipeline.get("archived", False):
+            continue
+        pipelines.append({
+            "name": pipeline["name"],
+            "full_name": pipeline["full_name"],
+            "html_url": f"https://github.com/{pipeline['full_name']}",
+        })
+
+    logger.info(f"Found {len(pipelines)} active pipelines")
+    return pipelines
+
+
+def clone_pipeline(pipeline: dict) -> Path:
+    """Clone a pipeline repository, preferring the 'dev' branch."""
+    repo_path = PIPELINES_DIR / pipeline["name"]
+
+    if repo_path.exists():
+        logger.debug(f"Pipeline already cloned: {pipeline['name']}")
+        try:
+            subprocess.run(
+                ["git", "-C", str(repo_path), "fetch", "--quiet", "origin", "dev"],
+                check=True,
+                capture_output=True,
+            )
+            subprocess.run(
+                ["git", "-C", str(repo_path), "checkout", "--quiet", "dev"],
+                check=True,
+                capture_output=True,
+            )
+        except subprocess.CalledProcessError:
+            pass
+        subprocess.run(
+            ["git", "-C", str(repo_path), "pull", "--quiet"],
+            check=True,
+            capture_output=True,
+        )
+    else:
+        logger.info(f"Cloning {pipeline['full_name']}...")
+        PIPELINES_DIR.mkdir(parents=True, exist_ok=True)
+        try:
+            subprocess.run(
+                ["git", "clone", "--quiet", "--depth", "1", "--branch", "dev", pipeline["html_url"], str(repo_path)],
+                check=True,
+                capture_output=True,
+            )
+        except subprocess.CalledProcessError:
+            subprocess.run(
+                ["git", "clone", "--quiet", "--depth", "1", pipeline["html_url"], str(repo_path)],
+                check=True,
+                capture_output=True,
+            )
+
+    return repo_path
+
+
+def lint_pipeline(repo_path: Path) -> dict:
+    """Run nextflow lint on a pipeline (JSON output for parsing)."""
+    result = subprocess.run(
+        ["nextflow", "lint", ".", "-o", "json"],
+        cwd=repo_path,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+    try:
+        lint_result = json.loads(result.stdout)
+        lint_result["parse_error"] = False
+        return lint_result
+    except json.JSONDecodeError:
+        logger.warning(f"Failed to parse lint output for {repo_path.name}")
+        logger.debug(f"stdout: {result.stdout}")
+        logger.debug(f"stderr: {result.stderr}")
+        return {"summary": {"errors": 0}, "errors": [], "warnings": [], "parse_error": True}
+
+
+@dlt.source(name="strict_syntax")
+def strict_syntax_source(pipelines_filter: list[str] | None = None):
+    """DLT source for strict-syntax linting data."""
+    logger.info("Initialized strict-syntax linting source")
+
+    nf_version = get_nextflow_version()
+    logger.info(f"Nextflow version: {nf_version}")
+
+    pipelines = fetch_pipelines()
+    if pipelines_filter:
+        filter_set = set(pipelines_filter)
+        pipelines = [p for p in pipelines if p["name"] in filter_set]
+        logger.info(f"Filtered to {len(pipelines)} pipelines: {', '.join(p['name'] for p in pipelines)}")
+
+    # Run linting and collect results
+    results = []
+    for pipeline in pipelines:
+        logger.info(f"Processing {pipeline['name']}...")
+        try:
+            repo_path = clone_pipeline(pipeline)
+            lint_result = lint_pipeline(repo_path)
+            results.append({
+                "name": pipeline["name"],
+                "full_name": pipeline["full_name"],
+                "html_url": pipeline["html_url"],
+                "errors": lint_result.get("summary", {}).get("errors", 0),
+                "warnings": len(lint_result.get("warnings", [])),
+                "parse_error": lint_result.get("parse_error", False),
+            })
+        except subprocess.CalledProcessError as e:
+            logger.error(f"Failed to process {pipeline['name']}: {e}")
+            results.append({
+                "name": pipeline["name"],
+                "full_name": pipeline["full_name"],
+                "html_url": pipeline["html_url"],
+                "errors": 0,
+                "warnings": 0,
+                "parse_error": True,
+            })
+
+    return [
+        dlt.resource(strict_syntax_history(results, nf_version), name="strict_syntax_history"),
+        dlt.resource(strict_syntax_pipelines(results), name="strict_syntax_pipelines"),
+    ]
+
+
+@dlt.resource(write_disposition="merge", primary_key=["date"])
+def strict_syntax_history(results: list[dict], nf_version: str) -> Iterator[dict]:
+    """Generate aggregated history entry from lint results."""
+    valid_results = [r for r in results if not r.get("parse_error", False)]
+    parse_error_count = sum(1 for r in results if r.get("parse_error", False))
+
+    today = datetime.now(timezone.utc).strftime("%Y-%m-%d")
+
+    yield {
+        "date": today,
+        "nextflow_version": nf_version,
+        "total_pipelines": len(results),
+        "parse_errors": parse_error_count,
+        "errors_zero": sum(1 for r in valid_results if r["errors"] == 0),
+        "errors_low": sum(1 for r in valid_results if 0 < r["errors"] <= 5),
+        "errors_high": sum(1 for r in valid_results if r["errors"] > 5),
+        "warnings_zero": sum(1 for r in valid_results if r["warnings"] == 0),
+        "warnings_low": sum(1 for r in valid_results if 0 < r["warnings"] <= 20),
+        "warnings_high": sum(1 for r in valid_results if r["warnings"] > 20),
+        "total_errors": sum(r["errors"] for r in valid_results),
+        "total_warnings": sum(r["warnings"] for r in valid_results),
+    }
+
+
+@dlt.resource(write_disposition="replace", primary_key=["pipeline_name"])
+def strict_syntax_pipelines(results: list[dict]) -> Iterator[dict]:
+    """Generate per-pipeline lint results."""
+    for r in results:
+        yield {
+            "pipeline_name": r["name"],
+            "full_name": r["full_name"],
+            "html_url": r["html_url"],
+            "parse_error": r["parse_error"],
+            "errors": r["errors"] if not r["parse_error"] else None,
+            "warnings": r["warnings"] if not r["parse_error"] else None,
+            "updated_at": datetime.now(timezone.utc).isoformat(),
+        }
+
+
+def main(
+    *,
+    destination: str = "motherduck",
+    pipelines: Annotated[str | None, "Comma-separated list of pipelines to lint"] = None,
+):
+    """Run the strict-syntax linting pipeline.
+
+    Args:
+        destination: dlt backend. Use 'motherduck' for production. Can use 'duckdb' for local testing
+        pipelines: Optional comma-separated list of pipeline names to lint (default: all)
+    """
+    logger.info("Starting strict-syntax linting pipeline...")
+
+    pipelines_filter = None
+    if pipelines:
+        pipelines_filter = [p.strip() for p in pipelines.split(",") if p.strip()]
+
+    pipeline = dlt.pipeline(
+        pipeline_name="strict_syntax_pipeline",
+        destination=destination,
+        dataset_name="strict_syntax",
+    )
+
+    load_info = pipeline.run(strict_syntax_source(pipelines_filter))
+
+    log_pipeline_stats(pipeline, load_info)
+
+    logger.info("Strict-syntax linting pipeline completed successfully!")

--- a/pipeline/src/nf_core_stats/strict_syntax_pipeline.py
+++ b/pipeline/src/nf_core_stats/strict_syntax_pipeline.py
@@ -1,310 +1,334 @@
-"""DLT pipeline for strict-syntax linting of nf-core pipelines.
+"""DLT pipeline for Nextflow strict syntax linting across nf-core."""
 
-This pipeline:
-1. Fetches the list of nf-core pipelines from nf-co.re
-2. Clones each pipeline and runs `nextflow lint`
-3. Stores results in MotherDuck for visualization in Evidence.dev
-"""
-
-import json
-import subprocess
 from collections.abc import Iterator
 from datetime import datetime, timezone
-from pathlib import Path
 from typing import Annotated
 
 import dlt
-import httpx
 
 from ._logging import log_pipeline_stats, logger
-
-PIPELINES_URL = "https://nf-co.re/pipelines.json"
-PIPELINES_DIR = Path("pipelines")
-NEXTFLOW_REPO = "https://github.com/nextflow-io/nextflow.git"
-
-
-def get_nextflow_sha() -> str:
-    """Get Nextflow HEAD commit SHA from remote."""
-    result = subprocess.run(
-        ["git", "ls-remote", NEXTFLOW_REPO, "HEAD"],
-        capture_output=True,
-        text=True,
-        check=True,
-    )
-    return result.stdout.split()[0]
+from .strict_syntax.fetch import fetch_pipelines
+from .strict_syntax.history import create_history_entry
+from .strict_syntax.lint import workflow_output_state
+from .strict_syntax.modules import (
+    discover_modules,
+    discover_subworkflows,
+    lint_modules,
+    lint_subworkflows,
+    prepare_modules_repo,
+)
+from .strict_syntax.nextflow import get_nextflow_sha, get_nextflow_version
+from .strict_syntax.pipelines import lint_pipelines
 
 
-def get_remote_head_sha(repo_url: str) -> str | None:
-    """Get HEAD commit SHA from remote without cloning."""
-    try:
-        # Try dev branch first
-        result = subprocess.run(
-            ["git", "ls-remote", repo_url, "refs/heads/dev"],
-            capture_output=True,
-            text=True,
-            check=True,
-        )
-        if result.stdout.strip():
-            return result.stdout.split()[0]
-        # Fallback to default branch
-        result = subprocess.run(
-            ["git", "ls-remote", repo_url, "HEAD"],
-            capture_output=True,
-            text=True,
-            check=True,
-        )
-        return result.stdout.split()[0] if result.stdout.strip() else None
-    except subprocess.CalledProcessError:
-        return None
-
-
-def get_nextflow_version() -> str:
-    """Get the current nextflow version."""
-    try:
-        result = subprocess.run(["nextflow", "-version"], capture_output=True, text=True, check=False)
-        for line in result.stdout.split("\n"):
-            if "version" in line.lower():
-                parts = line.split()
-                for i, part in enumerate(parts):
-                    if part.lower() == "version" and i + 1 < len(parts):
-                        return parts[i + 1]
-    except FileNotFoundError:
-        logger.warning("Nextflow not found in PATH")
-    return "unknown"
-
-
-def fetch_pipelines() -> list[dict]:
-    """Fetch pipeline list from nf-co.re."""
-    logger.info(f"Fetching pipelines from {PIPELINES_URL}")
-    response = httpx.get(PIPELINES_URL, timeout=60)
-    response.raise_for_status()
-    data = response.json()
-
-    pipelines = []
-    for pipeline in data.get("remote_workflows", []):
-        if pipeline.get("archived", False):
-            continue
-        pipelines.append({
-            "name": pipeline["name"],
-            "full_name": pipeline["full_name"],
-            "html_url": f"https://github.com/{pipeline['full_name']}",
-        })
-
-    logger.info(f"Found {len(pipelines)} active pipelines")
-    return pipelines
-
-
-def clone_pipeline(pipeline: dict) -> Path:
-    """Clone a pipeline repository, preferring the 'dev' branch."""
-    repo_path = PIPELINES_DIR / pipeline["name"]
-
-    if repo_path.exists():
-        logger.debug(f"Pipeline already cloned: {pipeline['name']}")
-        try:
-            subprocess.run(
-                ["git", "-C", str(repo_path), "fetch", "--quiet", "origin", "dev"],
-                check=True,
-                capture_output=True,
-            )
-            subprocess.run(
-                ["git", "-C", str(repo_path), "checkout", "--quiet", "dev"],
-                check=True,
-                capture_output=True,
-            )
-        except subprocess.CalledProcessError:
-            pass
-        subprocess.run(
-            ["git", "-C", str(repo_path), "pull", "--quiet"],
-            check=True,
-            capture_output=True,
-        )
-    else:
-        logger.info(f"Cloning {pipeline['full_name']}...")
-        PIPELINES_DIR.mkdir(parents=True, exist_ok=True)
-        try:
-            subprocess.run(
-                ["git", "clone", "--quiet", "--depth", "1", "--branch", "dev", pipeline["html_url"], str(repo_path)],
-                check=True,
-                capture_output=True,
-            )
-        except subprocess.CalledProcessError:
-            subprocess.run(
-                ["git", "clone", "--quiet", "--depth", "1", pipeline["html_url"], str(repo_path)],
-                check=True,
-                capture_output=True,
-            )
-
-    return repo_path
-
-
-def lint_pipeline(repo_path: Path) -> dict:
-    """Run nextflow lint on a pipeline (JSON output for parsing)."""
-    result = subprocess.run(
-        ["nextflow", "lint", ".", "-o", "json"],
-        cwd=repo_path,
-        capture_output=True,
-        text=True,
-        check=False,
-    )
-
-    try:
-        lint_result = json.loads(result.stdout)
-        lint_result["parse_error"] = False
-        return lint_result
-    except json.JSONDecodeError:
-        logger.warning(f"Failed to parse lint output for {repo_path.name}")
-        logger.debug(f"stdout: {result.stdout}")
-        logger.debug(f"stderr: {result.stderr}")
-        return {"summary": {"errors": 0}, "errors": [], "warnings": [], "parse_error": True}
-
-
-@dlt.resource(write_disposition="replace", primary_key=["pipeline_name"])
-def strict_syntax_lint_results(
-    pipelines: list[dict],
-    nf_version: str,
-    nf_sha: str,
-) -> Iterator[dict]:
-    """Lint pipelines with caching based on (nf_sha, pipeline_sha).
-
-    State is accessed here (inside @dlt.resource) so it persists correctly.
-    Also stores aggregated stats in state for the history resource.
-    """
-    state = dlt.current.source_state()
-    last_analyzed = state.setdefault("last_analyzed", {})
-
-    skipped = 0
-    processed = 0
-    results_for_history: list[dict] = []
-
-    for pipeline in pipelines:
-        name = pipeline["name"]
-        repo_url = pipeline["html_url"]
-        pipeline_sha = get_remote_head_sha(repo_url)
-
-        # Check cache
-        cached = last_analyzed.get(name, {})
-        if (
-            pipeline_sha
-            and cached.get("nf_sha") == nf_sha
-            and cached.get("pipeline_sha") == pipeline_sha
-        ):
-            logger.info(f"Skipping unchanged: {name}")
-            skipped += 1
-            continue
-
-        logger.info(f"Processing {name}...")
-        try:
-            repo_path = clone_pipeline(pipeline)
-            lint_result = lint_pipeline(repo_path)
-            result = {
-                "name": name,
-                "full_name": pipeline["full_name"],
-                "html_url": repo_url,
-                "errors": lint_result.get("summary", {}).get("errors", 0),
-                "warnings": len(lint_result.get("warnings", [])),
-                "parse_error": lint_result.get("parse_error", False),
-                "commit_sha": pipeline_sha,
-                "nextflow_sha": nf_sha,
-            }
-            # Update state on success
-            last_analyzed[name] = {"nf_sha": nf_sha, "pipeline_sha": pipeline_sha}
-        except subprocess.CalledProcessError as e:
-            logger.error(f"Failed to process {name}: {e}")
-            result = {
-                "name": name,
-                "full_name": pipeline["full_name"],
-                "html_url": repo_url,
-                "errors": 0,
-                "warnings": 0,
-                "parse_error": True,
-                "commit_sha": pipeline_sha,
-                "nextflow_sha": nf_sha,
-            }
-
-        results_for_history.append(result)
-        processed += 1
-
-        # Yield pipeline result
-        yield {
-            "pipeline_name": result["name"],
-            "full_name": result["full_name"],
-            "html_url": result["html_url"],
-            "parse_error": result["parse_error"],
-            "errors": result["errors"] if not result["parse_error"] else None,
-            "warnings": result["warnings"] if not result["parse_error"] else None,
-            "commit_sha": result.get("commit_sha"),
-            "nextflow_sha": result.get("nextflow_sha"),
-            "updated_at": datetime.now(timezone.utc).isoformat(),
-        }
-
-    logger.info(f"Processed {processed} pipelines, skipped {skipped} unchanged")
-
-    # Store aggregated stats in state for history resource
-    valid_results = [r for r in results_for_history if not r.get("parse_error", False)]
-    state["history_data"] = {
-        "date": datetime.now(timezone.utc).strftime("%Y-%m-%d"),
-        "nextflow_version": nf_version,
-        "nextflow_sha": nf_sha,
-        "total_pipelines": processed,
-        "parse_errors": sum(1 for r in results_for_history if r.get("parse_error", False)),
-        "errors_zero": sum(1 for r in valid_results if r["errors"] == 0),
-        "errors_low": sum(1 for r in valid_results if 0 < r["errors"] <= 5),
-        "errors_high": sum(1 for r in valid_results if r["errors"] > 5),
-        "warnings_zero": sum(1 for r in valid_results if r["warnings"] == 0),
-        "warnings_low": sum(1 for r in valid_results if 0 < r["warnings"] <= 20),
-        "warnings_high": sum(1 for r in valid_results if r["warnings"] > 20),
-        "total_errors": sum(r["errors"] for r in valid_results),
-        "total_warnings": sum(r["warnings"] for r in valid_results),
+def _history_row(
+    *,
+    component_type: str,
+    date: str,
+    nextflow_version: str,
+    nextflow_sha: str,
+    entry: dict,
+) -> dict:
+    return {
+        "date": date,
+        "component_type": component_type,
+        "nextflow_version": nextflow_version,
+        "nextflow_sha": nextflow_sha,
+        **entry,
     }
 
 
-@dlt.resource(write_disposition="merge", primary_key=["date"])
-def strict_syntax_history() -> Iterator[dict]:
-    """Generate aggregated history entry from state (populated by lint_results)."""
-    state = dlt.current.source_state()
-    history_data = state.get("history_data")
-    if history_data:
-        yield history_data
+@dlt.resource(write_disposition="replace", primary_key=["pipeline_name"])
+def strict_syntax_pipelines_resource(
+    rows: list[dict],
+    *,
+    nextflow_version: str,
+    nextflow_sha: str,
+) -> Iterator[dict]:
+    now = datetime.now(timezone.utc).isoformat()
+    for row in rows:
+        yield {
+            "pipeline_name": row["name"],
+            "full_name": row["full_name"],
+            "html_url": row["html_url"],
+            "parse_error": row.get("parse_error", False),
+            "errors": row.get("errors") if not row.get("parse_error") else None,
+            "warnings": row.get("warnings") if not row.get("parse_error") else None,
+            "prints_help": row.get("prints_help"),
+            "workflow_output": row.get("workflow_output"),
+            "publishdir": row.get("publishdir"),
+            "workflow_output_state": workflow_output_state(row),
+            "commit_sha": row.get("commit_sha"),
+            "nextflow_sha": nextflow_sha,
+            "nextflow_version": nextflow_version,
+            "lint_output": row.get("lint_output"),
+            "help_output": row.get("help_output"),
+            "updated_at": now,
+        }
+
+
+@dlt.resource(write_disposition="replace", primary_key=["module_name"])
+def strict_syntax_modules_resource(
+    rows: list[dict],
+    *,
+    nextflow_version: str,
+    nextflow_sha: str,
+    repo_commit: str | None,
+) -> Iterator[dict]:
+    now = datetime.now(timezone.utc).isoformat()
+    for row in rows:
+        yield {
+            "module_name": row["name"],
+            "html_url": row["html_url"],
+            "parse_error": row.get("parse_error", False),
+            "errors": row.get("errors") if not row.get("parse_error") else None,
+            "warnings": row.get("warnings") if not row.get("parse_error") else None,
+            "commit_sha": repo_commit,
+            "nextflow_sha": nextflow_sha,
+            "nextflow_version": nextflow_version,
+            "lint_output": row.get("lint_output"),
+            "updated_at": now,
+        }
+
+
+@dlt.resource(write_disposition="replace", primary_key=["subworkflow_name"])
+def strict_syntax_subworkflows_resource(
+    rows: list[dict],
+    *,
+    nextflow_version: str,
+    nextflow_sha: str,
+    repo_commit: str | None,
+) -> Iterator[dict]:
+    now = datetime.now(timezone.utc).isoformat()
+    for row in rows:
+        yield {
+            "subworkflow_name": row["name"],
+            "html_url": row["html_url"],
+            "parse_error": row.get("parse_error", False),
+            "errors": row.get("errors") if not row.get("parse_error") else None,
+            "warnings": row.get("warnings") if not row.get("parse_error") else None,
+            "commit_sha": repo_commit,
+            "nextflow_sha": nextflow_sha,
+            "nextflow_version": nextflow_version,
+            "lint_output": row.get("lint_output"),
+            "updated_at": now,
+        }
+
+
+@dlt.resource(write_disposition="merge", primary_key=["date", "component_type"])
+def strict_syntax_history_resource(history_rows: list[dict]) -> Iterator[dict]:
+    yield from history_rows
 
 
 @dlt.source(name="strict_syntax")
-def strict_syntax_source(pipelines_filter: list[str] | None = None):
-    """DLT source for strict-syntax linting data."""
-    logger.info("Initialized strict-syntax linting source")
-
+def strict_syntax_source(
+    *,
+    pipelines_filter: list[str] | None = None,
+    modules_filter: list[str] | None = None,
+    subworkflows_filter: list[str] | None = None,
+    skip_pipelines: bool = False,
+    skip_modules: bool = False,
+    skip_subworkflows: bool = False,
+    no_cache: bool = False,
+):
+    """Collect strict syntax lint results for nf-core pipelines, modules, and subworkflows."""
+    state = dlt.current.source_state()
     nf_version = get_nextflow_version()
     nf_sha = get_nextflow_sha()
-    logger.info(f"Nextflow version: {nf_version} (sha: {nf_sha[:8]})")
+    date = datetime.now(timezone.utc).strftime("%Y-%m-%d")
+    logger.info("Nextflow version: %s (sha: %s)", nf_version, nf_sha[:8])
 
-    pipelines = fetch_pipelines()
-    if pipelines_filter:
-        filter_set = set(pipelines_filter)
-        pipelines = [p for p in pipelines if p["name"] in filter_set]
-        logger.info(f"Filtered to {len(pipelines)} pipelines: {', '.join(p['name'] for p in pipelines)}")
+    resources = []
+    history_rows: list[dict] = []
 
-    # Return resources - state is accessed inside these (works correctly)
-    return [
-        strict_syntax_lint_results(pipelines, nf_version, nf_sha),
-        strict_syntax_history(),
-    ]
+    if not skip_pipelines:
+        pipelines = fetch_pipelines()
+        if pipelines_filter:
+            pipelines = [row for row in pipelines if row["name"] in pipelines_filter]
+            logger.info("Filtered to %d pipelines", len(pipelines))
+
+        pipeline_snapshot = state.setdefault("pipelines_snapshot", {})
+        pipeline_rows, pipeline_snapshot = lint_pipelines(
+            pipelines,
+            snapshot=pipeline_snapshot,
+            nextflow_version=nf_version,
+            no_cache=no_cache,
+        )
+        state["pipelines_snapshot"] = pipeline_snapshot
+
+        resources.append(
+            strict_syntax_pipelines_resource(pipeline_rows, nextflow_version=nf_version, nextflow_sha=nf_sha)
+        )
+        if not pipelines_filter:
+            entry = create_history_entry(pipeline_rows, include_prints_help=True)
+            history_rows.append(
+                _history_row(
+                    component_type="pipelines",
+                    date=date,
+                    nextflow_version=nf_version,
+                    nextflow_sha=nf_sha,
+                    entry=entry,
+                )
+            )
+
+    if not skip_modules or not skip_subworkflows:
+        modules_snapshot = state.setdefault("modules_snapshot", {})
+        repo_unchanged, repo_commit = prepare_modules_repo(
+            snapshot=modules_snapshot,
+            no_cache=no_cache,
+            check_modules=not skip_modules,
+            check_subworkflows=not skip_subworkflows,
+        )
+
+        if not skip_modules:
+            if repo_unchanged and not modules_filter:
+                discovered = discover_modules()
+                module_rows = [
+                    {
+                        "name": item["name"],
+                        "html_url": item["html_url"],
+                        "errors": modules_snapshot.get("modules", {}).get(item["name"], {}).get("errors", 0),
+                        "warnings": modules_snapshot.get("modules", {}).get(item["name"], {}).get("warnings", 0),
+                        "parse_error": modules_snapshot.get("modules", {})
+                        .get(item["name"], {})
+                        .get("parse_error", False),
+                        "lint_output": modules_snapshot.get("modules", {})
+                        .get(item["name"], {})
+                        .get("lint_output"),
+                    }
+                    for item in discovered
+                ]
+            else:
+                modules = discover_modules()
+                if modules_filter:
+                    modules = [row for row in modules if row["name"] in modules_filter]
+                module_rows, module_data = lint_modules(
+                    modules,
+                    snapshot=modules_snapshot.get("modules", {}),
+                    nextflow_version=nf_version,
+                    no_cache=no_cache or bool(modules_filter),
+                )
+                modules_snapshot["modules"] = module_data
+                if repo_commit:
+                    modules_snapshot["_repo_commit"] = repo_commit
+                state["modules_snapshot"] = modules_snapshot
+
+            resources.append(
+                strict_syntax_modules_resource(
+                    module_rows,
+                    nextflow_version=nf_version,
+                    nextflow_sha=nf_sha,
+                    repo_commit=modules_snapshot.get("_repo_commit"),
+                )
+            )
+            if not modules_filter:
+                entry = create_history_entry(module_rows)
+                history_rows.append(
+                    _history_row(
+                        component_type="modules",
+                        date=date,
+                        nextflow_version=nf_version,
+                        nextflow_sha=nf_sha,
+                        entry=entry,
+                    )
+                )
+
+        if not skip_subworkflows:
+            if repo_unchanged and not subworkflows_filter:
+                discovered = discover_subworkflows()
+                subworkflow_rows = [
+                    {
+                        "name": item["name"],
+                        "html_url": item["html_url"],
+                        "errors": modules_snapshot.get("subworkflows", {}).get(item["name"], {}).get("errors", 0),
+                        "warnings": modules_snapshot.get("subworkflows", {})
+                        .get(item["name"], {})
+                        .get("warnings", 0),
+                        "parse_error": modules_snapshot.get("subworkflows", {})
+                        .get(item["name"], {})
+                        .get("parse_error", False),
+                        "lint_output": modules_snapshot.get("subworkflows", {})
+                        .get(item["name"], {})
+                        .get("lint_output"),
+                    }
+                    for item in discovered
+                ]
+            else:
+                subworkflows = discover_subworkflows()
+                if subworkflows_filter:
+                    subworkflows = [row for row in subworkflows if row["name"] in subworkflows_filter]
+                subworkflow_rows, subworkflow_data = lint_subworkflows(
+                    subworkflows,
+                    snapshot=modules_snapshot.get("subworkflows", {}),
+                    nextflow_version=nf_version,
+                    no_cache=no_cache or bool(subworkflows_filter),
+                )
+                modules_snapshot["subworkflows"] = subworkflow_data
+                if repo_commit:
+                    modules_snapshot["_repo_commit"] = repo_commit
+                state["modules_snapshot"] = modules_snapshot
+
+            resources.append(
+                strict_syntax_subworkflows_resource(
+                    subworkflow_rows,
+                    nextflow_version=nf_version,
+                    nextflow_sha=nf_sha,
+                    repo_commit=modules_snapshot.get("_repo_commit"),
+                )
+            )
+            if not subworkflows_filter:
+                entry = create_history_entry(subworkflow_rows)
+                history_rows.append(
+                    _history_row(
+                        component_type="subworkflows",
+                        date=date,
+                        nextflow_version=nf_version,
+                        nextflow_sha=nf_sha,
+                        entry=entry,
+                    )
+                )
+
+    if history_rows:
+        resources.append(strict_syntax_history_resource(history_rows))
+
+    return resources
+
+
+def _split_csv(value: str | None) -> list[str] | None:
+    if not value:
+        return None
+    items = [part.strip() for part in value.split(",") if part.strip()]
+    return items or None
 
 
 def main(
     *,
     destination: str = "motherduck",
-    pipelines: Annotated[str | None, "Comma-separated list of pipelines to lint"] = None,
+    pipelines: Annotated[str | None, "Comma-separated pipeline names to lint"] = None,
+    modules: Annotated[str | None, "Comma-separated module names to lint"] = None,
+    subworkflows: Annotated[str | None, "Comma-separated subworkflow names to lint"] = None,
+    skip_pipelines: Annotated[bool, "Skip linting pipelines"] = False,
+    skip_modules: Annotated[bool, "Skip linting modules"] = False,
+    skip_subworkflows: Annotated[bool, "Skip linting subworkflows"] = False,
+    no_cache: Annotated[bool, "Ignore commit cache and re-lint everything"] = False,
+    backfill_history: Annotated[str | None, "Path to strict-syntax-health lint_results directory"] = None,
 ):
-    """Run the strict-syntax linting pipeline.
-
-    Args:
-        destination: dlt backend. Use 'motherduck' for production. Can use 'duckdb' for local testing
-        pipelines: Optional comma-separated list of pipeline names to lint (default: all)
-    """
+    """Run strict syntax linting and load results into MotherDuck."""
     logger.info("Starting strict-syntax linting pipeline...")
 
-    pipelines_filter = None
-    if pipelines:
-        pipelines_filter = [p.strip() for p in pipelines.split(",") if p.strip()]
+    if backfill_history:
+        from .strict_syntax.backfill import load_history_backfill
+
+        history_rows = load_history_backfill(backfill_history)
+        pipeline = dlt.pipeline(
+            pipeline_name="strict_syntax_pipeline",
+            destination=destination,
+            dataset_name="strict_syntax",
+        )
+        load_info = pipeline.run(strict_syntax_history_resource(history_rows))
+        log_pipeline_stats(pipeline, load_info)
+        logger.info("History backfill completed!")
+        return
 
     pipeline = dlt.pipeline(
         pipeline_name="strict_syntax_pipeline",
@@ -312,8 +336,17 @@ def main(
         dataset_name="strict_syntax",
     )
 
-    load_info = pipeline.run(strict_syntax_source(pipelines_filter))
+    load_info = pipeline.run(
+        strict_syntax_source(
+            pipelines_filter=_split_csv(pipelines),
+            modules_filter=_split_csv(modules),
+            subworkflows_filter=_split_csv(subworkflows),
+            skip_pipelines=skip_pipelines,
+            skip_modules=skip_modules,
+            skip_subworkflows=skip_subworkflows,
+            no_cache=no_cache,
+        )
+    )
 
     log_pipeline_stats(pipeline, load_info)
-
     logger.info("Strict-syntax linting pipeline completed successfully!")

--- a/pipeline/uv.lock
+++ b/pipeline/uv.lock
@@ -448,6 +448,7 @@ source = { editable = "." }
 dependencies = [
     { name = "cyclopts" },
     { name = "dlt", extra = ["cli", "duckdb", "motherduck"] },
+    { name = "httpx" },
     { name = "python-dotenv" },
     { name = "requests" },
     { name = "semanticscholar" },
@@ -458,6 +459,7 @@ dependencies = [
 requires-dist = [
     { name = "cyclopts", specifier = ">=4.1.0" },
     { name = "dlt", extras = ["cli", "duckdb", "motherduck"], specifier = ">=1.18.2" },
+    { name = "httpx", specifier = ">=0.27.0" },
     { name = "python-dotenv", specifier = "==1.2.2" },
     { name = "requests", specifier = ">=2.31.0" },
     { name = "semanticscholar", specifier = ">=0.11.0" },

--- a/sources/nfcore_db/strict_syntax_history.sql
+++ b/sources/nfcore_db/strict_syntax_history.sql
@@ -1,0 +1,24 @@
+USE nf_core_stats_bot;
+
+SELECT
+    date,
+    nextflow_version,
+    total_pipelines,
+    parse_errors,
+    errors_zero,
+    errors_low,
+    errors_high,
+    warnings_zero,
+    warnings_low,
+    warnings_high,
+    total_errors,
+    total_warnings,
+    -- Calculated percentages (excluding parse errors from denominator)
+    errors_zero / nullif(total_pipelines - parse_errors, 0)::float as errors_zero_pct,
+    errors_low / nullif(total_pipelines - parse_errors, 0)::float as errors_low_pct,
+    errors_high / nullif(total_pipelines - parse_errors, 0)::float as errors_high_pct,
+    warnings_zero / nullif(total_pipelines - parse_errors, 0)::float as warnings_zero_pct,
+    warnings_low / nullif(total_pipelines - parse_errors, 0)::float as warnings_low_pct,
+    warnings_high / nullif(total_pipelines - parse_errors, 0)::float as warnings_high_pct
+FROM strict_syntax.strict_syntax_history
+ORDER BY date DESC;

--- a/sources/nfcore_db/strict_syntax_history.sql
+++ b/sources/nfcore_db/strict_syntax_history.sql
@@ -1,7 +1,7 @@
 USE nf_core_stats_bot;
 
 SELECT
-    date,
+    date::DATE as date,
     nextflow_version,
     total_pipelines,
     parse_errors,

--- a/sources/nfcore_db/strict_syntax_history.sql
+++ b/sources/nfcore_db/strict_syntax_history.sql
@@ -2,8 +2,9 @@ USE nf_core_stats_bot;
 
 SELECT
     date::DATE as date,
+    component_type,
     nextflow_version,
-    total_pipelines,
+    total,
     parse_errors,
     errors_zero,
     errors_low,
@@ -13,12 +14,16 @@ SELECT
     warnings_high,
     total_errors,
     total_warnings,
-    -- Calculated percentages (excluding parse errors from denominator)
-    errors_zero / nullif(total_pipelines - parse_errors, 0)::float as errors_zero_pct,
-    errors_low / nullif(total_pipelines - parse_errors, 0)::float as errors_low_pct,
-    errors_high / nullif(total_pipelines - parse_errors, 0)::float as errors_high_pct,
-    warnings_zero / nullif(total_pipelines - parse_errors, 0)::float as warnings_zero_pct,
-    warnings_low / nullif(total_pipelines - parse_errors, 0)::float as warnings_low_pct,
-    warnings_high / nullif(total_pipelines - parse_errors, 0)::float as warnings_high_pct
+    prints_help_pass,
+    prints_help_fail,
+    workflow_output_pass,
+    workflow_output_warn,
+    workflow_output_error,
+    errors_zero / nullif(total - parse_errors, 0)::float as errors_zero_pct,
+    errors_low / nullif(total - parse_errors, 0)::float as errors_low_pct,
+    errors_high / nullif(total - parse_errors, 0)::float as errors_high_pct,
+    warnings_zero / nullif(total - parse_errors, 0)::float as warnings_zero_pct,
+    warnings_low / nullif(total - parse_errors, 0)::float as warnings_low_pct,
+    warnings_high / nullif(total - parse_errors, 0)::float as warnings_high_pct
 FROM strict_syntax.strict_syntax_history
-ORDER BY date DESC;
+ORDER BY date DESC, component_type;

--- a/sources/nfcore_db/strict_syntax_modules.sql
+++ b/sources/nfcore_db/strict_syntax_modules.sql
@@ -1,20 +1,15 @@
 USE nf_core_stats_bot;
 
 SELECT
-    pipeline_name,
-    full_name,
+    module_name,
     html_url,
     parse_error,
     errors,
     warnings,
-    prints_help,
-    workflow_output_state,
-    workflow_output,
-    publishdir,
     commit_sha,
     nextflow_version,
     updated_at
-FROM strict_syntax.strict_syntax_pipelines
+FROM strict_syntax.strict_syntax_modules
 ORDER BY
     parse_error DESC,
     errors DESC NULLS LAST,

--- a/sources/nfcore_db/strict_syntax_pipelines.sql
+++ b/sources/nfcore_db/strict_syntax_pipelines.sql
@@ -1,0 +1,15 @@
+USE nf_core_stats_bot;
+
+SELECT
+    pipeline_name,
+    full_name,
+    html_url,
+    parse_error,
+    errors,
+    warnings,
+    updated_at
+FROM strict_syntax.strict_syntax_pipelines
+ORDER BY
+    parse_error DESC,
+    errors DESC NULLS LAST,
+    warnings DESC NULLS LAST;

--- a/sources/nfcore_db/strict_syntax_subworkflows.sql
+++ b/sources/nfcore_db/strict_syntax_subworkflows.sql
@@ -1,20 +1,15 @@
 USE nf_core_stats_bot;
 
 SELECT
-    pipeline_name,
-    full_name,
+    subworkflow_name,
     html_url,
     parse_error,
     errors,
     warnings,
-    prints_help,
-    workflow_output_state,
-    workflow_output,
-    publishdir,
     commit_sha,
     nextflow_version,
     updated_at
-FROM strict_syntax.strict_syntax_pipelines
+FROM strict_syntax.strict_syntax_subworkflows
 ORDER BY
     parse_error DESC,
     errors DESC NULLS LAST,


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Migrates [nf-core/strict-syntax-health](https://github.com/nf-core/strict-syntax-health) into this repo, superseding the open draft PR #111 with full parity for pipelines, modules, and subworkflows.

## Changes

- **DLT pipeline** (`nf_core_stats strict-syntax`): nightly lint results loaded into MotherDuck
- **`strict_syntax/` package**: ported linting logic with commit-based caching, bulk module/subworkflow lint, `prints_help`, and workflow outputs tracking
- **History fix**: aggregates from full snapshots (cached + newly linted), not just delta rows
- **Evidence page** (`/code/strict_syntax`): tabs for pipelines, modules, and subworkflows
- **CI** (`.github/workflows/lint_strict_syntax.yml`): uses `nf-core/setup-nextflow`, 180min timeout, full workflow_dispatch inputs
- **Backfill**: `--backfill-history` flag to import JSON history from the old repo
- **Deprecation guide**: [docs/strict_syntax_migration.md](docs/strict_syntax_migration.md)

## Data model (MotherDuck `strict_syntax` dataset)

| Table | Description |
|-------|-------------|
| `strict_syntax_pipelines` | Per-pipeline lint snapshot with workflow outputs + prints_help |
| `strict_syntax_modules` | ~1,900 module results |
| `strict_syntax_subworkflows` | Subworkflow results |
| `strict_syntax_history` | Daily aggregates by `component_type` |

Lint output is stored in MotherDuck (`lint_output` column) rather than committing ~2,000 markdown files to git.

## Post-merge

1. Run history backfill against strict-syntax-health JSON (see docs)
2. Verify nightly CI workflow succeeds
3. Deprecate nf-core/strict-syntax-health per migration doc
4. Close PR #111

## Test plan

- [x] `uv run nf_core_stats strict-syntax --help` succeeds
- [x] Ruff lint passes on new code
- [ ] CI workflow_dispatch smoke test with `--pipelines rnaseq --skip-modules --skip-subworkflows`
- [ ] Full nightly run populates MotherDuck tables
- [ ] Evidence page renders at `/code/strict_syntax` after `npm run sources`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-222749a7-cd5b-4c15-9692-179320e3bb7a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-222749a7-cd5b-4c15-9692-179320e3bb7a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

