### PR TITLE
Strict syntax page: README parity follow-ups

### DIFF
--- a/.github/workflows/lint_strict_syntax.yml
+++ b/.github/workflows/lint_strict_syntax.yml
@@ -74,6 +74,12 @@ jobs:
           ./runitor -version
           sudo mv runitor /usr/local/bin/
 
+      - name: Backfill strict-syntax-health history
+        run: |
+          git clone --depth 1 https://github.com/nf-core/strict-syntax-health ../strict-syntax-health
+          uv run nf_core_stats strict-syntax \
+            --backfill-history ../strict-syntax-health/lint_results
+
       - name: Run strict-syntax pipeline
         run: |
           CMD=(uv run nf_core_stats strict-syntax)

--- a/components/StrictSyntaxReport.svelte
+++ b/components/StrictSyntaxReport.svelte
@@ -3,15 +3,106 @@
     export let column;
     export let title;
     export let emptyMessage = "No output captured.";
+    export let format = "markdown";
+
+    const htmlReplacements = {
+        "&": "&amp;",
+        "<": "&lt;",
+        ">": "&gt;",
+        '"': "&quot;",
+        "'": "&#39;",
+    };
+
+    function escapeHtml(value) {
+        return String(value).replace(/[&<>"']/g, (char) => htmlReplacements[char]);
+    }
+
+    function renderInlineMarkdown(value) {
+        return escapeHtml(value)
+            .replace(/\[([^\]]+)\]\((https?:\/\/[^)]+)\)/g, '<a href="$2" target="_blank" rel="noreferrer">$1</a>')
+            .replace(/`([^`]+)`/g, "<code>$1</code>")
+            .replace(/\*\*([^*]+)\*\*/g, "<strong>$1</strong>");
+    }
+
+    function closeList(html, inList) {
+        if (inList) {
+            html.push("</ul>");
+        }
+        return false;
+    }
+
+    function renderMarkdown(value) {
+        const html = [];
+        let inList = false;
+        let inCodeBlock = false;
+
+        for (const line of String(value).split("\n")) {
+            const trimmed = line.trim();
+
+            if (trimmed.startsWith("```")) {
+                inList = closeList(html, inList);
+                if (inCodeBlock) {
+                    html.push("</code></pre>");
+                } else {
+                    html.push("<pre><code>");
+                }
+                inCodeBlock = !inCodeBlock;
+                continue;
+            }
+
+            if (inCodeBlock) {
+                html.push(`${escapeHtml(line.replace(/^    /, ""))}\n`);
+                continue;
+            }
+
+            if (!trimmed) {
+                inList = closeList(html, inList);
+                continue;
+            }
+
+            const headingMatch = trimmed.match(/^(#{1,4})\s+(.+)$/);
+            if (headingMatch) {
+                inList = closeList(html, inList);
+                const level = headingMatch[1].length + 2;
+                html.push(`<h${level}>${renderInlineMarkdown(headingMatch[2])}</h${level}>`);
+                continue;
+            }
+
+            if (trimmed.startsWith("- ")) {
+                if (!inList) {
+                    html.push("<ul>");
+                    inList = true;
+                }
+                html.push(`<li>${renderInlineMarkdown(trimmed.slice(2))}</li>`);
+                continue;
+            }
+
+            inList = closeList(html, inList);
+            html.push(`<p>${renderInlineMarkdown(trimmed)}</p>`);
+        }
+
+        closeList(html, inList);
+        if (inCodeBlock) {
+            html.push("</code></pre>");
+        }
+        return html.join("\n");
+    }
 
     $: row = Array.isArray(data) ? data[0] : data?.[0];
     $: content = row?.[column] ?? "";
+    $: renderedContent = format === "markdown" ? renderMarkdown(content) : escapeHtml(content);
 </script>
 
 <section class="strict-syntax-report">
     <h2>{title}</h2>
     {#if content}
-        <pre>{content}</pre>
+        {#if format === "markdown"}
+            <div class="markdown report-body">
+                {@html renderedContent}
+            </div>
+        {:else}
+            <pre>{content}</pre>
+        {/if}
     {:else}
         <p><em>{emptyMessage}</em></p>
     {/if}
@@ -20,6 +111,26 @@
 <style>
     .strict-syntax-report {
         margin-top: 2rem;
+    }
+
+    .report-body {
+        padding: 1rem;
+        border: 1px solid var(--grey-200, #e5e7eb);
+        border-radius: 0.5rem;
+        background: var(--grey-50, #f9fafb);
+    }
+
+    :global(.report-body pre) {
+        max-height: 24rem;
+        overflow: auto;
+        padding: 1rem;
+        border-radius: 0.5rem;
+        background: var(--grey-100, #f3f4f6);
+        white-space: pre-wrap;
+    }
+
+    :global(.report-body code) {
+        font-size: 0.9em;
     }
 
     pre {

--- a/components/StrictSyntaxReport.svelte
+++ b/components/StrictSyntaxReport.svelte
@@ -1,103 +1,28 @@
 <script>
+    import MarkdownIt from "markdown-it";
+
     export let data = [];
     export let column;
     export let title;
     export let emptyMessage = "No output captured.";
     export let format = "markdown";
 
-    const htmlReplacements = {
-        "&": "&amp;",
-        "<": "&lt;",
-        ">": "&gt;",
-        '"': "&quot;",
-        "'": "&#39;",
-    };
-
-    function escapeHtml(value) {
-        return String(value).replace(/[&<>"']/g, (char) => htmlReplacements[char]);
-    }
-
-    function renderInlineMarkdown(value) {
-        return escapeHtml(value)
-            .replace(/\[([^\]]+)\]\((https?:\/\/[^)]+)\)/g, '<a href="$2" target="_blank" rel="noreferrer">$1</a>')
-            .replace(/`([^`]+)`/g, "<code>$1</code>")
-            .replace(/\*\*([^*]+)\*\*/g, "<strong>$1</strong>");
-    }
-
-    function closeList(html, inList) {
-        if (inList) {
-            html.push("</ul>");
-        }
-        return false;
-    }
-
-    function renderMarkdown(value) {
-        const html = [];
-        let inList = false;
-        let inCodeBlock = false;
-
-        for (const line of String(value).split("\n")) {
-            const trimmed = line.trim();
-
-            if (trimmed.startsWith("```")) {
-                inList = closeList(html, inList);
-                if (inCodeBlock) {
-                    html.push("</code></pre>");
-                } else {
-                    html.push("<pre><code>");
-                }
-                inCodeBlock = !inCodeBlock;
-                continue;
-            }
-
-            if (inCodeBlock) {
-                html.push(`${escapeHtml(line.replace(/^    /, ""))}\n`);
-                continue;
-            }
-
-            if (!trimmed) {
-                inList = closeList(html, inList);
-                continue;
-            }
-
-            const headingMatch = trimmed.match(/^(#{1,4})\s+(.+)$/);
-            if (headingMatch) {
-                inList = closeList(html, inList);
-                const level = headingMatch[1].length + 2;
-                html.push(`<h${level}>${renderInlineMarkdown(headingMatch[2])}</h${level}>`);
-                continue;
-            }
-
-            if (trimmed.startsWith("- ")) {
-                if (!inList) {
-                    html.push("<ul>");
-                    inList = true;
-                }
-                html.push(`<li>${renderInlineMarkdown(trimmed.slice(2))}</li>`);
-                continue;
-            }
-
-            inList = closeList(html, inList);
-            html.push(`<p>${renderInlineMarkdown(trimmed)}</p>`);
-        }
-
-        closeList(html, inList);
-        if (inCodeBlock) {
-            html.push("</code></pre>");
-        }
-        return html.join("\n");
-    }
+    const markdown = new MarkdownIt({
+        breaks: true,
+        html: false,
+        linkify: true,
+    });
 
     $: row = Array.isArray(data) ? data[0] : data?.[0];
     $: content = row?.[column] ?? "";
-    $: renderedContent = format === "markdown" ? renderMarkdown(content) : escapeHtml(content);
+    $: renderedContent = markdown.render(content);
 </script>
 
 <section class="strict-syntax-report">
     <h2>{title}</h2>
     {#if content}
         {#if format === "markdown"}
-            <div class="markdown report-body">
+            <div class="strict-syntax-markdown report-body">
                 {@html renderedContent}
             </div>
         {:else}
@@ -129,8 +54,28 @@
         white-space: pre-wrap;
     }
 
+    :global(.report-body h1) {
+        margin-top: 0;
+        font-size: 1.5rem;
+        font-weight: 700;
+    }
+
+    :global(.report-body h2) {
+        margin-top: 1.5rem;
+        font-size: 1.25rem;
+        font-weight: 650;
+    }
+
+    :global(.report-body ul) {
+        margin-left: 1.25rem;
+        list-style: disc;
+    }
+
     :global(.report-body code) {
         font-size: 0.9em;
+        padding: 0.1rem 0.25rem;
+        border-radius: 0.25rem;
+        background: var(--grey-100, #f3f4f6);
     }
 
     pre {

--- a/components/StrictSyntaxReport.svelte
+++ b/components/StrictSyntaxReport.svelte
@@ -1,0 +1,34 @@
+<script>
+    export let data = [];
+    export let column;
+    export let title;
+    export let emptyMessage = "No output captured.";
+
+    $: row = Array.isArray(data) ? data[0] : data?.[0];
+    $: content = row?.[column] ?? "";
+</script>
+
+<section class="strict-syntax-report">
+    <h2>{title}</h2>
+    {#if content}
+        <pre>{content}</pre>
+    {:else}
+        <p><em>{emptyMessage}</em></p>
+    {/if}
+</section>
+
+<style>
+    .strict-syntax-report {
+        margin-top: 2rem;
+    }
+
+    pre {
+        max-height: 42rem;
+        overflow: auto;
+        padding: 1rem;
+        border: 1px solid var(--grey-200, #e5e7eb);
+        border-radius: 0.5rem;
+        background: var(--grey-50, #f9fafb);
+        white-space: pre-wrap;
+    }
+</style>

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,8 @@
         "@evidence-dev/csv": "^1.0.15",
         "@evidence-dev/duckdb": "^2.0.0",
         "@evidence-dev/evidence": "^40.1.6",
-        "@evidence-dev/motherduck": "^1.0.5"
+        "@evidence-dev/motherduck": "^1.0.5",
+        "markdown-it": "^14.2.0"
       },
       "engines": {
         "node": ">=18.0.0 <25.0.0",
@@ -437,6 +438,7 @@
     },
     "node_modules/@clack/prompts/node_modules/is-unicode-supported": {
       "version": "1.3.0",
+      "extraneous": true,
       "inBundle": true,
       "license": "MIT",
       "engines": {
@@ -7783,6 +7785,25 @@
       "integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==",
       "license": "MIT"
     },
+    "node_modules/linkify-it": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/linkify-it/-/linkify-it-5.0.1.tgz",
+      "integrity": "sha512-wVoTjP4Q6R0NW5hiZkVJaFZPWgtXfoGF+6LucL3/FtiNjmcHhYjEr5f1Kqjirc1nBW07J/ZuRFumqr2oqccEWg==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/markdown-it"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "uc.micro": "^2.0.0"
+      }
+    },
     "node_modules/locate-character": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/locate-character/-/locate-character-3.0.0.tgz",
@@ -7938,6 +7959,45 @@
         "url": "https://github.com/sponsors/wooorm"
       }
     },
+    "node_modules/markdown-it": {
+      "version": "14.2.0",
+      "resolved": "https://registry.npmjs.org/markdown-it/-/markdown-it-14.2.0.tgz",
+      "integrity": "sha512-1TGiQiJVRQ3NPmZH6sx5Cfnmg6GQm9jvC1ch4TK511NjSJvjzKLzn5pPfZRNZkRPZP0HqCioSndqH8v2nRaWVQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/markdown-it"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "argparse": "^2.0.1",
+        "entities": "^4.4.0",
+        "linkify-it": "^5.0.1",
+        "mdurl": "^2.0.0",
+        "punycode.js": "^2.3.1",
+        "uc.micro": "^2.1.0"
+      },
+      "bin": {
+        "markdown-it": "bin/markdown-it.mjs"
+      }
+    },
+    "node_modules/markdown-it/node_modules/entities": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
+      "integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
     "node_modules/math-intrinsics": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
@@ -7967,6 +8027,12 @@
       "peerDependencies": {
         "svelte": ">=3 <5"
       }
+    },
+    "node_modules/mdurl": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/mdurl/-/mdurl-2.0.0.tgz",
+      "integrity": "sha512-Lf+9+2r+Tdp5wXDXC4PcIBjTDtq4UKjCPMQhKIuzpJNW0b96kVqSwW0bT7FhRSfmAiFYgP+SCRvdrDozfh0U5w==",
+      "license": "MIT"
     },
     "node_modules/media-typer": {
       "version": "0.3.0",
@@ -9044,6 +9110,15 @@
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
       "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/punycode.js": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/punycode.js/-/punycode.js-2.3.1.tgz",
+      "integrity": "sha512-uxFIHU0YlHYhDQtV4R9J6a52SLx28BCjT+4ieh7IGbgwVJWO+km431c4yRlREUAsAmt/uMjQUyQHNEPf0M39CA==",
       "license": "MIT",
       "engines": {
         "node": ">=6"
@@ -10821,6 +10896,12 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/uc.micro": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/uc.micro/-/uc.micro-2.1.0.tgz",
+      "integrity": "sha512-ARDJmphmdvUk6Glw7y9DQ2bFkKBHwQHLi2lsaH6PPmz/Ka9sFOBsBluozhDltWmnv9u/cF6Rt87znRTPV+yp/A==",
+      "license": "MIT"
     },
     "node_modules/ufo": {
       "version": "1.6.3",

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "@evidence-dev/csv": "^1.0.15",
     "@evidence-dev/duckdb": "^2.0.0",
     "@evidence-dev/evidence": "^40.1.6",
-    "@evidence-dev/motherduck": "^1.0.5"
+    "@evidence-dev/motherduck": "^1.0.5",
+    "markdown-it": "^14.2.0"
   }
 }

--- a/pages/code/strict_syntax.md
+++ b/pages/code/strict_syntax.md
@@ -62,6 +62,12 @@ select * from nfcore_db.strict_syntax_subworkflows
 select max(updated_at) as last_updated from nfcore_db.strict_syntax_pipelines
 ```
 
+<div style="position: absolute; left: -9999px;" aria-hidden="true">
+{#each pipelines as pipeline}
+<a href="/code/strict_syntax/{pipeline.pipeline_name}">Pipeline detail {pipeline.pipeline_name}</a>
+{/each}
+</div>
+
 <Tabs>
     <Tab label="Pipelines">
 

--- a/pages/code/strict_syntax.md
+++ b/pages/code/strict_syntax.md
@@ -46,6 +46,36 @@ order by date desc
 limit 1
 ```
 
+```sql current_summary
+with latest as (
+    select
+        *,
+        row_number() over (partition by component_type order by date desc) as row_num
+    from nfcore_db.strict_syntax_history
+)
+select
+    case component_type
+        when 'pipelines' then 'Pipelines'
+        when 'modules' then 'Modules'
+        when 'subworkflows' then 'Subworkflows'
+    end as component,
+    total,
+    parse_errors,
+    errors_zero,
+    errors_zero / nullif(total - parse_errors, 0)::float as zero_errors_pct,
+    total_errors,
+    total_warnings,
+    nextflow_version
+from latest
+where row_num = 1
+order by
+    case component_type
+        when 'pipelines' then 1
+        when 'modules' then 2
+        when 'subworkflows' then 3
+    end
+```
+
 ```sql pipelines
 select * from nfcore_db.strict_syntax_pipelines
 ```
@@ -62,11 +92,18 @@ select * from nfcore_db.strict_syntax_subworkflows
 select max(updated_at) as last_updated from nfcore_db.strict_syntax_pipelines
 ```
 
-<div style="position: absolute; left: -9999px;" aria-hidden="true">
-{#each pipelines as pipeline}
-<a href="/code/strict_syntax/{pipeline.pipeline_name}">Pipeline detail {pipeline.pipeline_name}</a>
-{/each}
-</div>
+## Current Snapshot
+
+<DataTable data={current_summary} rows=all>
+    <Column id=component title="Component" />
+    <Column id=total title="Total" />
+    <Column id=parse_errors title="Parse Errors" />
+    <Column id=errors_zero title="Zero Errors" />
+    <Column id=zero_errors_pct title="Zero Errors %" fmt=pct1 />
+    <Column id=total_errors title="Errors" contentType=colorscale colorScale=negative />
+    <Column id=total_warnings title="Warnings" contentType=colorscale colorScale=warning />
+    <Column id=nextflow_version title="Nextflow" />
+</DataTable>
 
 <Tabs>
     <Tab label="Pipelines">
@@ -426,3 +463,9 @@ nextflow lint . -exclude ".git,.nf-test,nf-test.config"
 ## Getting Help
 
 If you need help fixing strict syntax errors, ask in the [Seqera community forum](https://community.seqera.io/).
+
+<div style="position: absolute; left: -9999px;" aria-hidden="true">
+{#each pipelines as pipeline}
+<a href="/code/strict_syntax/{pipeline.pipeline_name}">Pipeline detail {pipeline.pipeline_name}</a>
+{/each}
+</div>

--- a/pages/code/strict_syntax.md
+++ b/pages/code/strict_syntax.md
@@ -10,19 +10,40 @@ This page tracks adoption of [Nextflow strict syntax](https://www.nextflow.io/do
 ```sql pipeline_history
 select * from nfcore_db.strict_syntax_history
 where component_type = 'pipelines'
+order by date
+```
+
+```sql pipeline_latest
+select * from nfcore_db.strict_syntax_history
+where component_type = 'pipelines'
 order by date desc
+limit 1
 ```
 
 ```sql module_history
 select * from nfcore_db.strict_syntax_history
 where component_type = 'modules'
+order by date
+```
+
+```sql module_latest
+select * from nfcore_db.strict_syntax_history
+where component_type = 'modules'
 order by date desc
+limit 1
 ```
 
 ```sql subworkflow_history
 select * from nfcore_db.strict_syntax_history
 where component_type = 'subworkflows'
+order by date
+```
+
+```sql subworkflow_latest
+select * from nfcore_db.strict_syntax_history
+where component_type = 'subworkflows'
 order by date desc
+limit 1
 ```
 
 ```sql pipelines
@@ -37,28 +58,51 @@ select * from nfcore_db.strict_syntax_modules
 select * from nfcore_db.strict_syntax_subworkflows
 ```
 
+```sql pipeline_updated_at
+select max(updated_at) as last_updated from nfcore_db.strict_syntax_pipelines
+```
+
 <Tabs>
     <Tab label="Pipelines">
 
 ## Pipeline Status
 
+Latest snapshot: <Value data={pipeline_latest} column=parse_errors /> parse errors, <Value data={pipeline_latest} column=total_errors /> errors, and <Value data={pipeline_latest} column=total_warnings /> warnings across <Value data={pipeline_latest} column=total /> pipelines.
+
 <BigValue
-    data={pipeline_history}
+    data={pipeline_latest}
     value=total
     title="Total Pipelines"
-    sparkline=date
 />
 <BigValue
-    data={pipeline_history}
+    data={pipeline_latest}
     value=errors_zero
     title="Zero Errors"
-    sparkline=date
 />
 <BigValue
-    data={pipeline_history}
+    data={pipeline_latest}
+    value=total_errors
+    title="Total Errors"
+/>
+<BigValue
+    data={pipeline_latest}
+    value=total_warnings
+    title="Total Warnings"
+/>
+<BigValue
+    data={pipeline_latest}
     value=workflow_output_pass
     title="Workflow Outputs Migrated"
-    sparkline=date
+/>
+<BigValue
+    data={pipeline_latest}
+    value=nextflow_version
+    title="Nextflow Version"
+/>
+<BigValue
+    data={pipeline_updated_at}
+    value=last_updated
+    title="Last Updated"
 />
 
 ## Pipeline Error Distribution
@@ -87,15 +131,86 @@ select * from nfcore_db.strict_syntax_subworkflows
     </Tab>
 </Tabs>
 
+## Pipeline Warning Distribution
+
+<Tabs>
+    <Tab label="Percentage">
+        <AreaChart
+            data={pipeline_history}
+            x=date
+            y={['warnings_zero_pct', 'warnings_low_pct', 'warnings_high_pct']}
+            title="Pipeline Warning Distribution (%)"
+            yFmt="pct0"
+            yMax={1}
+            seriesColors={['#2ecc71', '#f39c12', '#e74c3c']}
+        />
+    </Tab>
+    <Tab label="Counts">
+        <AreaChart
+            data={pipeline_history}
+            x=date
+            y={['warnings_zero', 'warnings_low', 'warnings_high']}
+            title="Pipeline Warning Distribution"
+            yAxisTitle="Number of Pipelines"
+            seriesColors={['#2ecc71', '#f39c12', '#e74c3c']}
+        />
+    </Tab>
+</Tabs>
+
+## Workflow Outputs Migration
+
+Adoption of the new [workflow outputs](https://docs.seqera.io/nextflow/tutorials/workflow-outputs) syntax (`output {}`) and migration away from legacy `publishDir`.
+
+- **Fully migrated:** <Value data={pipeline_latest} column=workflow_output_pass /> pipelines (<Value data={pipeline_latest} column=workflow_output_pass_pct fmt=pct1 />)
+- **In progress:** <Value data={pipeline_latest} column=workflow_output_warn /> pipelines (<Value data={pipeline_latest} column=workflow_output_warn_pct fmt=pct1 />)
+- **Not started:** <Value data={pipeline_latest} column=workflow_output_error /> pipelines (<Value data={pipeline_latest} column=workflow_output_error_pct fmt=pct1 />)
+
+<Tabs>
+    <Tab label="Percentage">
+        <AreaChart
+            data={pipeline_history}
+            x=date
+            y={['workflow_output_pass_pct', 'workflow_output_warn_pct', 'workflow_output_error_pct']}
+            title="Workflow Outputs Migration (%)"
+            yFmt="pct0"
+            yMax={1}
+            seriesColors={['#2ecc71', '#f39c12', '#e74c3c']}
+        />
+    </Tab>
+    <Tab label="Counts">
+        <AreaChart
+            data={pipeline_history}
+            x=date
+            y={['workflow_output_pass', 'workflow_output_warn', 'workflow_output_error']}
+            title="Workflow Outputs Migration"
+            yAxisTitle="Number of Pipelines"
+            seriesColors={['#2ecc71', '#f39c12', '#e74c3c']}
+        />
+    </Tab>
+</Tabs>
+
+<DataTable data={pipelines} search=true sort="workflow_output_state_sort asc">
+    <Column id=pipeline_name title="Pipeline" />
+    <Column id=workflow_output_state_label title="Status" />
+    <Column id=workflow_output_label title="Output Block" />
+    <Column id=publishdir_label title="publishDir" />
+    <Column id=workflow_output_report_url title="Report" contentType=link linkLabel="View" />
+    <Column id=html_url title="Repository" contentType=link linkLabel="View" />
+</DataTable>
+
 ## Per-Pipeline Breakdown
 
-<DataTable data={pipelines} search=true>
+Open a pipeline row, lint link, or help link for captured output details.
+
+<DataTable data={pipelines} search=true link=detail_url>
     <Column id=pipeline_name title="Pipeline" />
-    <Column id=parse_error title="Parse Error" />
+    <Column id=parse_error_label title="Parse Error" />
     <Column id=errors title="Errors" contentType=colorscale colorScale=negative />
     <Column id=warnings title="Warnings" contentType=colorscale colorScale=warning />
-    <Column id=prints_help title="Prints Help" />
-    <Column id=workflow_output_state title="Workflow Outputs" />
+    <Column id=prints_help_label title="Prints Help" />
+    <Column id=lint_output_url title="Lint Output" contentType=link linkLabel="View" />
+    <Column id=help_output_url title="Help Output" contentType=link linkLabel="View" />
+    <Column id=workflow_output_state_label title="Workflow Outputs" />
     <Column id=html_url title="Repository" contentType=link linkLabel="View" />
 </DataTable>
 
@@ -105,28 +220,77 @@ select * from nfcore_db.strict_syntax_subworkflows
 ## Module Status
 
 <BigValue
-    data={module_history}
+    data={module_latest}
     value=total
     title="Total Modules"
-    sparkline=date
 />
 <BigValue
-    data={module_history}
+    data={module_latest}
     value=errors_zero
     title="Zero Errors"
-    sparkline=date
+/>
+<BigValue
+    data={module_latest}
+    value=total_errors
+    title="Total Errors"
+/>
+<BigValue
+    data={module_latest}
+    value=total_warnings
+    title="Total Warnings"
 />
 
 ## Module Error Distribution
 
-<AreaChart
-    data={module_history}
-    x=date
-    y={['errors_zero', 'errors_low', 'errors_high']}
-    title="Module Error Distribution"
-    yAxisTitle="Number of Modules"
-    seriesColors={['#2ecc71', '#f39c12', '#e74c3c']}
-/>
+<Tabs>
+    <Tab label="Percentage">
+        <AreaChart
+            data={module_history}
+            x=date
+            y={['errors_zero_pct', 'errors_low_pct', 'errors_high_pct']}
+            title="Module Error Distribution (%)"
+            yFmt="pct0"
+            yMax={1}
+            seriesColors={['#2ecc71', '#f39c12', '#e74c3c']}
+        />
+    </Tab>
+    <Tab label="Counts">
+        <AreaChart
+            data={module_history}
+            x=date
+            y={['errors_zero', 'errors_low', 'errors_high']}
+            title="Module Error Distribution"
+            yAxisTitle="Number of Modules"
+            seriesColors={['#2ecc71', '#f39c12', '#e74c3c']}
+        />
+    </Tab>
+</Tabs>
+
+## Module Warning Distribution
+
+<Tabs>
+    <Tab label="Percentage">
+        <AreaChart
+            data={module_history}
+            x=date
+            y={['warnings_zero_pct', 'warnings_low_pct', 'warnings_high_pct']}
+            title="Module Warning Distribution (%)"
+            yFmt="pct0"
+            yMax={1}
+            seriesColors={['#2ecc71', '#f39c12', '#e74c3c']}
+        />
+    </Tab>
+    <Tab label="Counts">
+        <AreaChart
+            data={module_history}
+            x=date
+            y={['warnings_zero', 'warnings_low', 'warnings_high']}
+            title="Module Warning Distribution"
+            yAxisTitle="Number of Modules"
+            seriesColors={['#2ecc71', '#f39c12', '#e74c3c']}
+        />
+    </Tab>
+</Tabs>
 
 ## Per-Module Breakdown
 
@@ -144,28 +308,77 @@ select * from nfcore_db.strict_syntax_subworkflows
 ## Subworkflow Status
 
 <BigValue
-    data={subworkflow_history}
+    data={subworkflow_latest}
     value=total
     title="Total Subworkflows"
-    sparkline=date
 />
 <BigValue
-    data={subworkflow_history}
+    data={subworkflow_latest}
     value=errors_zero
     title="Zero Errors"
-    sparkline=date
+/>
+<BigValue
+    data={subworkflow_latest}
+    value=total_errors
+    title="Total Errors"
+/>
+<BigValue
+    data={subworkflow_latest}
+    value=total_warnings
+    title="Total Warnings"
 />
 
 ## Subworkflow Error Distribution
 
-<AreaChart
-    data={subworkflow_history}
-    x=date
-    y={['errors_zero', 'errors_low', 'errors_high']}
-    title="Subworkflow Error Distribution"
-    yAxisTitle="Number of Subworkflows"
-    seriesColors={['#2ecc71', '#f39c12', '#e74c3c']}
-/>
+<Tabs>
+    <Tab label="Percentage">
+        <AreaChart
+            data={subworkflow_history}
+            x=date
+            y={['errors_zero_pct', 'errors_low_pct', 'errors_high_pct']}
+            title="Subworkflow Error Distribution (%)"
+            yFmt="pct0"
+            yMax={1}
+            seriesColors={['#2ecc71', '#f39c12', '#e74c3c']}
+        />
+    </Tab>
+    <Tab label="Counts">
+        <AreaChart
+            data={subworkflow_history}
+            x=date
+            y={['errors_zero', 'errors_low', 'errors_high']}
+            title="Subworkflow Error Distribution"
+            yAxisTitle="Number of Subworkflows"
+            seriesColors={['#2ecc71', '#f39c12', '#e74c3c']}
+        />
+    </Tab>
+</Tabs>
+
+## Subworkflow Warning Distribution
+
+<Tabs>
+    <Tab label="Percentage">
+        <AreaChart
+            data={subworkflow_history}
+            x=date
+            y={['warnings_zero_pct', 'warnings_low_pct', 'warnings_high_pct']}
+            title="Subworkflow Warning Distribution (%)"
+            yFmt="pct0"
+            yMax={1}
+            seriesColors={['#2ecc71', '#f39c12', '#e74c3c']}
+        />
+    </Tab>
+    <Tab label="Counts">
+        <AreaChart
+            data={subworkflow_history}
+            x=date
+            y={['warnings_zero', 'warnings_low', 'warnings_high']}
+            title="Subworkflow Warning Distribution"
+            yAxisTitle="Number of Subworkflows"
+            seriesColors={['#2ecc71', '#f39c12', '#e74c3c']}
+        />
+    </Tab>
+</Tabs>
 
 ## Per-Subworkflow Breakdown
 
@@ -182,9 +395,28 @@ select * from nfcore_db.strict_syntax_subworkflows
 
 ## About
 
-Nightly `nextflow lint` runs via the stats repo pipeline (migrated from [nf-core/strict-syntax-health](https://github.com/nf-core/strict-syntax-health)).
+Nightly `nextflow lint` runs via the stats repo pipeline, migrated from [nf-core/strict-syntax-health](https://github.com/nf-core/strict-syntax-health). See the [nf-core roadmap blog post](https://nf-co.re/blog/2025/nextflow_syntax_nf-core_roadmap) for the strict syntax timeline.
 
-- **Zero errors**: Fully compliant with strict syntax
-- **1-5 errors**: Minor issues to fix
-- **>5 errors**: Significant work needed
-- **Workflow outputs**: Migration from `publishDir` to the new `output {}` block
+- **Parse errors** indicate items where `nextflow lint` could not run, typically because syntax errors prevent Nextflow from parsing the code.
+- **Errors** indicate syntax issues that will cause problems in future Nextflow versions.
+- **Warnings** indicate deprecated patterns that should be updated; warnings are allowed, but still worth fixing.
+- **Prints Help** tests whether a zero-error pipeline can print help with the v2 parser: `NXF_SYNTAX_PARSER=v2 nextflow run . --help`.
+- **Workflow Outputs Migration** tracks adoption of the new [workflow outputs](https://docs.seqera.io/nextflow/tutorials/workflow-outputs) syntax and migration away from `publishDir`. A pipeline is fully migrated once it uses `output {}` with no `publishDir`.
+
+## Running Locally
+
+Run strict syntax linting in a pipeline repository:
+
+```bash
+nextflow lint .
+```
+
+Until [nextflow-io/nextflow#6716](https://github.com/nextflow-io/nextflow/pull/6716) is included in a Nextflow edge release, you may need to exclude nf-test files manually:
+
+```bash
+nextflow lint . -exclude ".git,.nf-test,nf-test.config"
+```
+
+## Getting Help
+
+If you need help fixing strict syntax errors, ask in the [Seqera community forum](https://community.seqera.io/).

--- a/pages/code/strict_syntax.md
+++ b/pages/code/strict_syntax.md
@@ -7,91 +7,6 @@ sidebar_position: 10
 
 This page tracks adoption of [Nextflow strict syntax](https://www.nextflow.io/docs/latest/strict-syntax.html) across nf-core pipelines, modules, and subworkflows. **Fixing all errors from `nextflow lint` will be required by early spring 2026.**
 
-```sql pipeline_history
-select * from nfcore_db.strict_syntax_history
-where component_type = 'pipelines'
-order by date
-```
-
-```sql pipeline_latest
-select * from nfcore_db.strict_syntax_history
-where component_type = 'pipelines'
-order by date desc
-limit 1
-```
-
-```sql module_history
-select * from nfcore_db.strict_syntax_history
-where component_type = 'modules'
-order by date
-```
-
-```sql module_latest
-select * from nfcore_db.strict_syntax_history
-where component_type = 'modules'
-order by date desc
-limit 1
-```
-
-```sql subworkflow_history
-select * from nfcore_db.strict_syntax_history
-where component_type = 'subworkflows'
-order by date
-```
-
-```sql subworkflow_latest
-select * from nfcore_db.strict_syntax_history
-where component_type = 'subworkflows'
-order by date desc
-limit 1
-```
-
-```sql current_summary
-with latest as (
-    select
-        *,
-        row_number() over (partition by component_type order by date desc) as row_num
-    from nfcore_db.strict_syntax_history
-)
-select
-    case component_type
-        when 'pipelines' then 'Pipelines'
-        when 'modules' then 'Modules'
-        when 'subworkflows' then 'Subworkflows'
-    end as component,
-    total,
-    parse_errors,
-    errors_zero,
-    errors_zero / nullif(total - parse_errors, 0)::float as zero_errors_pct,
-    total_errors,
-    total_warnings,
-    nextflow_version
-from latest
-where row_num = 1
-order by
-    case component_type
-        when 'pipelines' then 1
-        when 'modules' then 2
-        when 'subworkflows' then 3
-    end
-```
-
-```sql pipelines
-select * from nfcore_db.strict_syntax_pipelines
-```
-
-```sql modules
-select * from nfcore_db.strict_syntax_modules
-```
-
-```sql subworkflows
-select * from nfcore_db.strict_syntax_subworkflows
-```
-
-```sql pipeline_updated_at
-select max(updated_at) as last_updated from nfcore_db.strict_syntax_pipelines
-```
-
 ## Current Snapshot
 
 <DataTable data={current_summary} rows=all>
@@ -463,6 +378,91 @@ nextflow lint . -exclude ".git,.nf-test,nf-test.config"
 ## Getting Help
 
 If you need help fixing strict syntax errors, ask in the [Seqera community forum](https://community.seqera.io/).
+
+```sql pipeline_history
+select * from nfcore_db.strict_syntax_history
+where component_type = 'pipelines'
+order by date
+```
+
+```sql pipeline_latest
+select * from nfcore_db.strict_syntax_history
+where component_type = 'pipelines'
+order by date desc
+limit 1
+```
+
+```sql module_history
+select * from nfcore_db.strict_syntax_history
+where component_type = 'modules'
+order by date
+```
+
+```sql module_latest
+select * from nfcore_db.strict_syntax_history
+where component_type = 'modules'
+order by date desc
+limit 1
+```
+
+```sql subworkflow_history
+select * from nfcore_db.strict_syntax_history
+where component_type = 'subworkflows'
+order by date
+```
+
+```sql subworkflow_latest
+select * from nfcore_db.strict_syntax_history
+where component_type = 'subworkflows'
+order by date desc
+limit 1
+```
+
+```sql current_summary
+with latest as (
+    select
+        *,
+        row_number() over (partition by component_type order by date desc) as row_num
+    from nfcore_db.strict_syntax_history
+)
+select
+    case component_type
+        when 'pipelines' then 'Pipelines'
+        when 'modules' then 'Modules'
+        when 'subworkflows' then 'Subworkflows'
+    end as component,
+    total,
+    parse_errors,
+    errors_zero,
+    errors_zero / nullif(total - parse_errors, 0)::float as zero_errors_pct,
+    total_errors,
+    total_warnings,
+    nextflow_version
+from latest
+where row_num = 1
+order by
+    case component_type
+        when 'pipelines' then 1
+        when 'modules' then 2
+        when 'subworkflows' then 3
+    end
+```
+
+```sql pipelines
+select * from nfcore_db.strict_syntax_pipelines
+```
+
+```sql modules
+select * from nfcore_db.strict_syntax_modules
+```
+
+```sql subworkflows
+select * from nfcore_db.strict_syntax_subworkflows
+```
+
+```sql pipeline_updated_at
+select max(updated_at) as last_updated from nfcore_db.strict_syntax_pipelines
+```
 
 <div style="position: absolute; left: -9999px;" aria-hidden="true">
 {#each pipelines as pipeline}

--- a/pages/code/strict_syntax.md
+++ b/pages/code/strict_syntax.md
@@ -13,11 +13,7 @@ This page tracks adoption of [Nextflow strict syntax](https://www.nextflow.io/do
     <Column id=component title="Component" />
     <Column id=total title="Total" />
     <Column id=parse_errors title="Parse Errors" />
-    <Column id=errors_zero title="Zero Errors" />
-    <Column id=zero_errors_pct title="Zero Errors %" fmt=pct1 />
-    <Column id=total_errors title="Errors" contentType=colorscale colorScale=negative />
-    <Column id=total_warnings title="Warnings" contentType=colorscale colorScale=warning />
-    <Column id=nextflow_version title="Nextflow" />
+    <Column id=zero_errors_label title="Zero Errors" />
 </DataTable>
 
 <Tabs>
@@ -433,11 +429,7 @@ select
     end as component,
     total,
     parse_errors,
-    errors_zero,
-    errors_zero / nullif(total - parse_errors, 0)::float as zero_errors_pct,
-    total_errors,
-    total_warnings,
-    nextflow_version
+    errors_zero || ' (' || printf('%.1f%%', 100 * errors_zero / nullif(total - parse_errors, 0)::float) || ')' as zero_errors_label
 from latest
 where row_num = 1
 order by

--- a/pages/code/strict_syntax.md
+++ b/pages/code/strict_syntax.md
@@ -429,7 +429,12 @@ select
     end as component,
     total,
     parse_errors,
-    errors_zero::INTEGER::VARCHAR || ' (' || printf('%.1f%%', 100 * errors_zero / nullif(total - parse_errors, 0)::float) || ')' as zero_errors_label
+    errors_zero::INTEGER::VARCHAR || ' (' ||
+        case
+            when total - parse_errors > 0 then printf('%.1f%%', 100 * errors_zero / (total - parse_errors)::float)
+            else '0.0%'
+        end ||
+    ')' as zero_errors_label
 from latest
 where row_num = 1
 order by

--- a/pages/code/strict_syntax.md
+++ b/pages/code/strict_syntax.md
@@ -429,7 +429,7 @@ select
     end as component,
     total,
     parse_errors,
-    errors_zero || ' (' || printf('%.1f%%', 100 * errors_zero / nullif(total - parse_errors, 0)::float) || ')' as zero_errors_label
+    errors_zero::INTEGER::VARCHAR || ' (' || printf('%.1f%%', 100 * errors_zero / nullif(total - parse_errors, 0)::float) || ')' as zero_errors_label
 from latest
 where row_num = 1
 order by

--- a/pages/code/strict_syntax/[pipeline].md
+++ b/pages/code/strict_syntax/[pipeline].md
@@ -40,6 +40,7 @@ where pipeline_name = '${params.pipeline}'
     data={pipeline_detail}
     column="help_output"
     title="Help Output"
+    format="text"
     emptyMessage="Help output is only captured for pipelines with zero lint errors."
 />
 

--- a/pages/code/strict_syntax/[pipeline].md
+++ b/pages/code/strict_syntax/[pipeline].md
@@ -1,0 +1,53 @@
+---
+title: Strict Syntax Pipeline Detail
+---
+
+```sql pipeline_detail
+select *
+from nfcore_db.strict_syntax_pipelines
+where pipeline_name = '${params.pipeline}'
+```
+
+# Strict syntax: {params.pipeline}
+
+[Back to strict syntax health](/code/strict_syntax)
+
+<BigValue data={pipeline_detail} value=errors title="Errors" />
+<BigValue data={pipeline_detail} value=warnings title="Warnings" />
+<BigValue data={pipeline_detail} value=prints_help_label title="Prints Help" />
+<BigValue data={pipeline_detail} value=workflow_output_state_label title="Workflow Outputs" />
+
+## Pipeline Status
+
+- **Repository:** <Value data={pipeline_detail} column=html_url />
+- **Parse error:** <Value data={pipeline_detail} column=parse_error_label />
+- **Nextflow version:** <Value data={pipeline_detail} column=nextflow_version />
+- **Workflow `output {}`:** <Value data={pipeline_detail} column=workflow_output_label />
+- **Legacy `publishDir`:** <Value data={pipeline_detail} column=publishdir_label />
+
+<div id="lint-output"></div>
+
+<StrictSyntaxReport
+    data={pipeline_detail}
+    column="lint_output"
+    title="Lint Output"
+    emptyMessage="No lint output was captured for this pipeline."
+/>
+
+<div id="help-output"></div>
+
+<StrictSyntaxReport
+    data={pipeline_detail}
+    column="help_output"
+    title="Help Output"
+    emptyMessage="Help output is only captured for pipelines with zero lint errors."
+/>
+
+<div id="workflow-outputs-report"></div>
+
+<StrictSyntaxReport
+    data={pipeline_detail}
+    column="workflow_output_report"
+    title="Workflow Outputs Report"
+    emptyMessage="No workflow outputs report was captured for this pipeline."
+/>

--- a/pipeline/scripts/seed_strict_syntax_demo.py
+++ b/pipeline/scripts/seed_strict_syntax_demo.py
@@ -1,0 +1,225 @@
+#!/usr/bin/env -S uv run python
+"""Seed a local DuckDB database with strict syntax demo data."""
+
+from __future__ import annotations
+
+import argparse
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+import duckdb
+
+
+def _utc_now() -> datetime:
+    return datetime.now(timezone.utc).replace(microsecond=0)
+
+
+def _workflow_report(name: str, output_count: int, publishdir_count: int) -> str:
+    return "\n".join(
+        [
+            "# Workflow outputs migration report",
+            "",
+            f"- Pipeline: {name}",
+            "- Nextflow version: 26.04.3",
+            f"- `output {{}}` matches: {output_count}",
+            f"- `publishDir` matches: {publishdir_count}",
+            "",
+            "## `output {}` matches",
+            "",
+            "- `workflows/main.nf:1`: `output {}`" if output_count else "- No matches found",
+            "",
+            "## `publishDir` matches",
+            "",
+            "- `conf/modules.config:12`: `publishDir = ...`" if publishdir_count else "- No matches found",
+        ]
+    )
+
+
+def _lint_output(name: str, errors: int, warnings: int) -> str:
+    summary = "No issues found" if errors == 0 and warnings == 0 else f"{errors} errors, {warnings} warnings"
+    return "\n".join(
+        [
+            "# Nextflow lint results",
+            "",
+            "- Nextflow version: 26.04.3",
+            f"- Pipeline: {name}",
+            f"- Summary: {summary}",
+            "",
+            "## Errors",
+            "",
+            "- `main.nf:42:1`: example strict syntax error" if errors else "- No errors found",
+            "",
+            "## Warnings",
+            "",
+            "- `modules.config:18:1`: example strict syntax warning" if warnings else "- No warnings found",
+        ]
+    )
+
+
+def _history_rows(now: datetime) -> list[tuple]:
+    today = now.date().isoformat()
+    yesterday = (now - timedelta(days=1)).date().isoformat()
+    return [
+        (yesterday, "pipelines", "26.04.2", "demo-sha", 4, 0, 2, 1, 1, 1, 1, 2, 130, 520, 2, 1, 0, 1, 3),
+        (today, "pipelines", "26.04.3", "demo-sha", 4, 0, 3, 0, 1, 1, 1, 2, 117, 1153, 2, 1, 1, 1, 2),
+        (yesterday, "modules", "26.04.2", "demo-sha", 5, 0, 5, 0, 0, 3, 1, 1, 0, 10, 0, 0, None, None, None),
+        (today, "modules", "26.04.3", "demo-sha", 5, 0, 5, 0, 0, 3, 2, 0, 0, 8, 0, 0, None, None, None),
+        (yesterday, "subworkflows", "26.04.2", "demo-sha", 3, 0, 3, 0, 0, 1, 1, 1, 0, 22, 0, 0, None, None, None),
+        (today, "subworkflows", "26.04.3", "demo-sha", 3, 0, 3, 0, 0, 1, 2, 0, 0, 16, 0, 0, None, None, None),
+    ]
+
+
+def seed(database: Path) -> None:
+    now = _utc_now()
+    database.parent.mkdir(parents=True, exist_ok=True)
+    conn = duckdb.connect(str(database))
+    conn.execute("CREATE SCHEMA IF NOT EXISTS strict_syntax")
+    conn.execute(
+        """
+        CREATE OR REPLACE TABLE strict_syntax.strict_syntax_history (
+            date DATE,
+            component_type VARCHAR,
+            nextflow_version VARCHAR,
+            nextflow_sha VARCHAR,
+            total INTEGER,
+            parse_errors INTEGER,
+            errors_zero INTEGER,
+            errors_low INTEGER,
+            errors_high INTEGER,
+            warnings_zero INTEGER,
+            warnings_low INTEGER,
+            warnings_high INTEGER,
+            total_errors INTEGER,
+            total_warnings INTEGER,
+            prints_help_pass INTEGER,
+            prints_help_fail INTEGER,
+            workflow_output_pass INTEGER,
+            workflow_output_warn INTEGER,
+            workflow_output_error INTEGER
+        )
+        """
+    )
+    conn.executemany(
+        "INSERT INTO strict_syntax.strict_syntax_history VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+        _history_rows(now),
+    )
+
+    pipeline_rows = [
+        ("createpanelrefs", "nf-core/createpanelrefs", "https://github.com/nf-core/createpanelrefs", False, 0, 2, True, True, False, "pass", 1, 0),
+        ("sarek", "nf-core/sarek", "https://github.com/nf-core/sarek", False, 0, 617, True, True, True, "warn", 1, 186),
+        ("eager", "nf-core/eager", "https://github.com/nf-core/eager", False, 117, 367, None, False, True, "error", 0, 127),
+        ("longraredisease", "nf-core/longraredisease", "https://github.com/nf-core/longraredisease", False, 0, 167, False, False, True, "error", 0, 76),
+    ]
+    conn.execute(
+        """
+        CREATE OR REPLACE TABLE strict_syntax.strict_syntax_pipelines (
+            pipeline_name VARCHAR,
+            full_name VARCHAR,
+            html_url VARCHAR,
+            parse_error BOOLEAN,
+            errors INTEGER,
+            warnings INTEGER,
+            prints_help BOOLEAN,
+            workflow_output BOOLEAN,
+            publishdir BOOLEAN,
+            workflow_output_state VARCHAR,
+            workflow_output_count INTEGER,
+            publishdir_count INTEGER,
+            commit_sha VARCHAR,
+            nextflow_sha VARCHAR,
+            nextflow_version VARCHAR,
+            lint_output VARCHAR,
+            help_output VARCHAR,
+            workflow_output_report VARCHAR,
+            updated_at TIMESTAMP
+        )
+        """
+    )
+    conn.executemany(
+        """
+        INSERT INTO strict_syntax.strict_syntax_pipelines
+        VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, 'demo-commit', 'demo-sha', '26.04.3', ?, ?, ?, ?)
+        """,
+        [
+            (
+                *row,
+                _lint_output(row[0], row[4], row[5]),
+                "$ NXF_SYNTAX_PARSER=v2 nextflow run . --help\n\nUsage: nextflow run nf-core/demo [options]\n"
+                if row[6] is not None
+                else None,
+                _workflow_report(row[0], row[10], row[11]),
+                now,
+            )
+            for row in pipeline_rows
+        ],
+    )
+
+    conn.execute(
+        """
+        CREATE OR REPLACE TABLE strict_syntax.strict_syntax_modules (
+            module_name VARCHAR,
+            html_url VARCHAR,
+            parse_error BOOLEAN,
+            errors INTEGER,
+            warnings INTEGER,
+            commit_sha VARCHAR,
+            nextflow_sha VARCHAR,
+            nextflow_version VARCHAR,
+            lint_output VARCHAR,
+            updated_at TIMESTAMP
+        )
+        """
+    )
+    conn.executemany(
+        "INSERT INTO strict_syntax.strict_syntax_modules VALUES (?, ?, ?, ?, ?, 'demo-commit', 'demo-sha', '26.04.3', ?, ?)",
+        [
+            ("bwa_mem", "https://github.com/nf-core/modules/tree/master/modules/nf-core/bwa/mem", False, 0, 0, _lint_output("bwa_mem", 0, 0), now),
+            ("samtools_sort", "https://github.com/nf-core/modules/tree/master/modules/nf-core/samtools/sort", False, 0, 2, _lint_output("samtools_sort", 0, 2), now),
+            ("fastqc", "https://github.com/nf-core/modules/tree/master/modules/nf-core/fastqc", False, 0, 6, _lint_output("fastqc", 0, 6), now),
+            ("multiqc", "https://github.com/nf-core/modules/tree/master/modules/nf-core/multiqc", False, 0, 0, _lint_output("multiqc", 0, 0), now),
+            ("salmon_quant", "https://github.com/nf-core/modules/tree/master/modules/nf-core/salmon/quant", False, 0, 0, _lint_output("salmon_quant", 0, 0), now),
+        ],
+    )
+
+    conn.execute(
+        """
+        CREATE OR REPLACE TABLE strict_syntax.strict_syntax_subworkflows (
+            subworkflow_name VARCHAR,
+            html_url VARCHAR,
+            parse_error BOOLEAN,
+            errors INTEGER,
+            warnings INTEGER,
+            commit_sha VARCHAR,
+            nextflow_sha VARCHAR,
+            nextflow_version VARCHAR,
+            lint_output VARCHAR,
+            updated_at TIMESTAMP
+        )
+        """
+    )
+    conn.executemany(
+        "INSERT INTO strict_syntax.strict_syntax_subworkflows VALUES (?, ?, ?, ?, ?, 'demo-commit', 'demo-sha', '26.04.3', ?, ?)",
+        [
+            ("bam_sort_stats_samtools", "https://github.com/nf-core/modules/tree/master/subworkflows/nf-core/bam_sort_stats_samtools", False, 0, 0, _lint_output("bam_sort_stats_samtools", 0, 0), now),
+            ("fastq_align_bwa", "https://github.com/nf-core/modules/tree/master/subworkflows/nf-core/fastq_align_bwa", False, 0, 10, _lint_output("fastq_align_bwa", 0, 10), now),
+            ("vcf_annotate", "https://github.com/nf-core/modules/tree/master/subworkflows/nf-core/vcf_annotate", False, 0, 6, _lint_output("vcf_annotate", 0, 6), now),
+        ],
+    )
+    conn.close()
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--database",
+        type=Path,
+        default=Path(__file__).resolve().parents[1] / "nf_core_stats_bot.duckdb",
+        help="Path to the DuckDB database to create or replace.",
+    )
+    args = parser.parse_args()
+    seed(args.database)
+    print(f"Seeded strict syntax demo data in {args.database}")
+
+
+if __name__ == "__main__":
+    main()

--- a/pipeline/src/nf_core_stats/strict_syntax/lint.py
+++ b/pipeline/src/nf_core_stats/strict_syntax/lint.py
@@ -32,12 +32,68 @@ def _scan_lines(repo_path: Path, patterns: tuple[str, ...], regex: re.Pattern) -
     return matches
 
 
+def find_workflow_output_matches(repo_path: Path) -> list[tuple[str, int, str]]:
+    return _scan_lines(repo_path, ("*.nf",), WORKFLOW_OUTPUT_RE)
+
+
+def find_publishdir_matches(repo_path: Path) -> list[tuple[str, int, str]]:
+    return _scan_lines(repo_path, ("*.nf", "*.config"), PUBLISHDIR_RE)
+
+
 def detect_workflow_output(repo_path: Path) -> bool:
-    return bool(_scan_lines(repo_path, ("*.nf",), WORKFLOW_OUTPUT_RE))
+    return bool(find_workflow_output_matches(repo_path))
 
 
 def detect_publishdir(repo_path: Path) -> bool:
-    return bool(_scan_lines(repo_path, ("*.nf", "*.config"), PUBLISHDIR_RE))
+    return bool(find_publishdir_matches(repo_path))
+
+
+def _format_matches(matches: list[tuple[str, int, str]]) -> list[str]:
+    if not matches:
+        return ["- No matches found"]
+
+    lines = [f"- `{filename}:{line_num}`: `{line}`" for filename, line_num, line in matches[:_MAX_REPORT_MATCHES]]
+    if len(matches) > _MAX_REPORT_MATCHES:
+        lines.append(f"- ... {len(matches) - _MAX_REPORT_MATCHES} more matches omitted")
+    return lines
+
+
+def generate_workflow_output_report(
+    *,
+    repo_name: str,
+    nextflow_version: str,
+    workflow_output_matches: list[tuple[str, int, str]],
+    publishdir_matches: list[tuple[str, int, str]],
+) -> str:
+    now = datetime.now(timezone.utc).isoformat()
+    workflow_output_count = len(workflow_output_matches)
+    publishdir_count = len(publishdir_matches)
+    if workflow_output_count and not publishdir_count:
+        state = "Fully migrated"
+    elif workflow_output_count:
+        state = "In progress"
+    else:
+        state = "Not started"
+
+    lines = [
+        "# Workflow outputs migration report",
+        "",
+        f"- Pipeline: {repo_name}",
+        f"- Generated: {now}",
+        f"- Nextflow version: {nextflow_version}",
+        f"- Status: {state}",
+        f"- `output {{}}` matches: {workflow_output_count}",
+        f"- `publishDir` matches: {publishdir_count}",
+        "",
+        "## `output {}` matches",
+        "",
+        *_format_matches(workflow_output_matches),
+        "",
+        "## `publishDir` matches",
+        "",
+        *_format_matches(publishdir_matches),
+    ]
+    return "\n".join(lines)
 
 
 def workflow_output_state(result: dict) -> str | None:

--- a/pipeline/src/nf_core_stats/strict_syntax/pipelines.py
+++ b/pipeline/src/nf_core_stats/strict_syntax/pipelines.py
@@ -4,9 +4,10 @@ from pathlib import Path
 from .._logging import logger
 from .git_utils import get_local_commit_hash, get_remote_head_sha
 from .lint import (
-    detect_publishdir,
-    detect_workflow_output,
+    find_publishdir_matches,
+    find_workflow_output_matches,
     generate_markdown_from_issues,
+    generate_workflow_output_report,
     lint_component,
     test_prints_help,
 )
@@ -66,7 +67,11 @@ def _cached_pipeline_row(pipeline: dict, cached: dict, commit: str) -> dict:
         "prints_help": cached.get("prints_help"),
         "workflow_output": cached.get("workflow_output"),
         "publishdir": cached.get("publishdir"),
+        "workflow_output_count": cached.get("workflow_output_count"),
+        "publishdir_count": cached.get("publishdir_count"),
+        "workflow_output_report": cached.get("workflow_output_report"),
         "lint_output": cached.get("lint_output"),
+        "help_output": cached.get("help_output"),
     }
 
 
@@ -77,7 +82,12 @@ def _needs_reprocess(cached: dict) -> bool:
         and cached.get("prints_help") is None
     )
     needs_output_detection = cached.get("workflow_output") is None or cached.get("publishdir") is None
-    return needs_prints_help or needs_output_detection
+    needs_output_report = (
+        cached.get("workflow_output_count") is None
+        or cached.get("publishdir_count") is None
+        or cached.get("workflow_output_report") is None
+    )
+    return needs_prints_help or needs_output_detection or needs_output_report
 
 
 def lint_pipelines(
@@ -118,8 +128,10 @@ def lint_pipelines(
             error_count = lint_result.get("summary", {}).get("errors", 0)
             warning_count = len(lint_result.get("warnings", []))
             parse_error = lint_result.get("parse_error", False)
-            workflow_output = detect_workflow_output(repo_path)
-            publishdir = detect_publishdir(repo_path)
+            workflow_output_matches = find_workflow_output_matches(repo_path)
+            publishdir_matches = find_publishdir_matches(repo_path)
+            workflow_output = bool(workflow_output_matches)
+            publishdir = bool(publishdir_matches)
 
             prints_help = None
             help_output = None
@@ -146,6 +158,14 @@ def lint_pipelines(
                 "prints_help": prints_help,
                 "workflow_output": workflow_output,
                 "publishdir": publishdir,
+                "workflow_output_count": len(workflow_output_matches),
+                "publishdir_count": len(publishdir_matches),
+                "workflow_output_report": generate_workflow_output_report(
+                    repo_name=name,
+                    nextflow_version=nextflow_version,
+                    workflow_output_matches=workflow_output_matches,
+                    publishdir_matches=publishdir_matches,
+                ),
                 "lint_output": lint_output,
                 "help_output": help_output,
             }
@@ -163,6 +183,9 @@ def lint_pipelines(
                 "prints_help": None,
                 "workflow_output": None,
                 "publishdir": None,
+                "workflow_output_count": None,
+                "publishdir_count": None,
+                "workflow_output_report": None,
                 "lint_output": None,
                 "help_output": None,
             }

--- a/pipeline/src/nf_core_stats/strict_syntax_pipeline.py
+++ b/pipeline/src/nf_core_stats/strict_syntax_pipeline.py
@@ -7,6 +7,7 @@ from typing import Annotated
 import dlt
 
 from ._logging import log_pipeline_stats, logger
+from .strict_syntax.backfill import load_history_backfill
 from .strict_syntax.fetch import fetch_pipelines
 from .strict_syntax.history import create_history_entry
 from .strict_syntax.lint import workflow_output_state
@@ -58,6 +59,9 @@ def strict_syntax_pipelines_resource(
             "workflow_output": row.get("workflow_output"),
             "publishdir": row.get("publishdir"),
             "workflow_output_state": workflow_output_state(row),
+            "workflow_output_count": row.get("workflow_output_count"),
+            "publishdir_count": row.get("publishdir_count"),
+            "workflow_output_report": row.get("workflow_output_report"),
             "commit_sha": row.get("commit_sha"),
             "nextflow_sha": nextflow_sha,
             "nextflow_version": nextflow_version,
@@ -317,8 +321,6 @@ def main(
     logger.info("Starting strict-syntax linting pipeline...")
 
     if backfill_history:
-        from .strict_syntax.backfill import load_history_backfill
-
         history_rows = load_history_backfill(backfill_history)
         pipeline = dlt.pipeline(
             pipeline_name="strict_syntax_pipeline",

--- a/sources/nfcore_db/strict_syntax_history.sql
+++ b/sources/nfcore_db/strict_syntax_history.sql
@@ -14,16 +14,19 @@ SELECT
     warnings_high,
     total_errors,
     total_warnings,
-    prints_help_pass,
-    prints_help_fail,
-    workflow_output_pass,
-    workflow_output_warn,
-    workflow_output_error,
+    coalesce(prints_help_pass, 0) as prints_help_pass,
+    coalesce(prints_help_fail, 0) as prints_help_fail,
+    coalesce(workflow_output_pass, 0) as workflow_output_pass,
+    coalesce(workflow_output_warn, 0) as workflow_output_warn,
+    coalesce(workflow_output_error, 0) as workflow_output_error,
     errors_zero / nullif(total - parse_errors, 0)::float as errors_zero_pct,
     errors_low / nullif(total - parse_errors, 0)::float as errors_low_pct,
     errors_high / nullif(total - parse_errors, 0)::float as errors_high_pct,
     warnings_zero / nullif(total - parse_errors, 0)::float as warnings_zero_pct,
     warnings_low / nullif(total - parse_errors, 0)::float as warnings_low_pct,
-    warnings_high / nullif(total - parse_errors, 0)::float as warnings_high_pct
+    warnings_high / nullif(total - parse_errors, 0)::float as warnings_high_pct,
+    coalesce(workflow_output_pass, 0) / nullif(total, 0)::float as workflow_output_pass_pct,
+    coalesce(workflow_output_warn, 0) / nullif(total, 0)::float as workflow_output_warn_pct,
+    coalesce(workflow_output_error, 0) / nullif(total, 0)::float as workflow_output_error_pct
 FROM strict_syntax.strict_syntax_history
 ORDER BY date DESC, component_type;

--- a/sources/nfcore_db/strict_syntax_pipelines.sql
+++ b/sources/nfcore_db/strict_syntax_pipelines.sql
@@ -1,20 +1,65 @@
 USE nf_core_stats_bot;
 
+WITH pipelines AS (
+    SELECT *
+    FROM strict_syntax.strict_syntax_pipelines
+    UNION ALL BY NAME
+    SELECT
+        NULL::INTEGER as workflow_output_count,
+        NULL::INTEGER as publishdir_count,
+        NULL::VARCHAR as workflow_output_report
+    WHERE FALSE
+)
 SELECT
     pipeline_name,
     full_name,
     html_url,
+    '/code/strict_syntax/' || pipeline_name as detail_url,
+    CASE WHEN lint_output IS NOT NULL THEN '/code/strict_syntax/' || pipeline_name || '#lint-output' END as lint_output_url,
+    CASE WHEN help_output IS NOT NULL THEN '/code/strict_syntax/' || pipeline_name || '#help-output' END as help_output_url,
+    CASE
+        WHEN workflow_output_report IS NOT NULL THEN '/code/strict_syntax/' || pipeline_name || '#workflow-outputs-report'
+    END as workflow_output_report_url,
     parse_error,
+    CASE WHEN parse_error THEN 'Yes' ELSE 'No' END as parse_error_label,
     errors,
     warnings,
     prints_help,
+    CASE
+        WHEN prints_help IS TRUE THEN 'Yes'
+        WHEN prints_help IS FALSE THEN 'No'
+        ELSE '-'
+    END as prints_help_label,
     workflow_output_state,
+    CASE workflow_output_state
+        WHEN 'pass' THEN 'Fully migrated'
+        WHEN 'warn' THEN 'In progress'
+        WHEN 'error' THEN 'Not started'
+        ELSE 'Unknown'
+    END as workflow_output_state_label,
+    CASE workflow_output_state
+        WHEN 'pass' THEN 1
+        WHEN 'warn' THEN 2
+        WHEN 'error' THEN 3
+        ELSE 4
+    END as workflow_output_state_sort,
     workflow_output,
+    CASE WHEN workflow_output THEN 'Yes' ELSE 'No' END as workflow_output_label,
+    workflow_output_count,
     publishdir,
+    CASE
+        WHEN publishdir AND publishdir_count IS NOT NULL THEN 'Yes (' || publishdir_count || ')'
+        WHEN publishdir THEN 'Yes'
+        ELSE 'No'
+    END as publishdir_label,
+    publishdir_count,
     commit_sha,
     nextflow_version,
+    lint_output,
+    help_output,
+    workflow_output_report,
     updated_at
-FROM strict_syntax.strict_syntax_pipelines
+FROM pipelines
 ORDER BY
     parse_error DESC,
     errors DESC NULLS LAST,


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Stacked on #132. Merge after #132 or rebase onto main once #132 lands.

Comparison doc: `docs/strict_syntax_migration.md`

## Summary
- Adds strict syntax README-parity dashboard sections for workflow outputs, warning distributions, and expanded guidance.
- Adds a simplified always-visible Current Snapshot table for pipelines, modules, and subworkflows above the detail tabs.
- Adds per-pipeline detail pages for lint output, help output, and workflow-output migration reports, with generated markdown reports rendered via `markdown-it`.
- Adds backward-compatible workflow-output report/count collection, a local DuckDB demo seed helper, and automated backfill from `nf-core/strict-syntax-health` in the strict syntax workflow.
- Moves inline query panels below the visible content so they no longer appear before the dashboard when query display is enabled.

## Walkthrough
[strict_syntax_clean_snapshot_markdown.mp4](https://cursor.com/agents/bc-8ce2f3ba-90fd-4b0d-b7ed-8daef7348935/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fstrict_syntax_clean_snapshot_markdown.mp4)

## Testing
- `uvx ruff check pipeline/src/nf_core_stats/ pipeline/scripts/seed_strict_syntax_demo.py`
- `git clone --depth 1 https://github.com/nf-core/strict-syntax-health /tmp/strict-syntax-health-test` followed by `load_history_backfill('/tmp/strict-syntax-health-test/lint_results')`, which returned 457 rows across pipelines/modules/subworkflows.
- `uv run --project pipeline python pipeline/scripts/seed_strict_syntax_demo.py`
- `npm run sources` against a temporary local DuckDB connection; strict syntax sources wrote demo rows, unrelated source errors are expected with the strict-syntax-only demo database.
- `npm run build` against the same temporary local DuckDB connection; build completed and wrote `./build`, with expected unrelated missing-source warnings.
- Manual browser walkthrough on `http://localhost:3000/code/strict_syntax` verified the simplified snapshot table, no `NaN%`, and markdown-rendered reports.

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#team-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-8ce2f3ba-90fd-4b0d-b7ed-8daef7348935"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-8ce2f3ba-90fd-4b0d-b7ed-8daef7348935"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

