### PR TITLE
Set up Claude previews + secure MotherDuck token (1Password/direnv) + DuckDB 1.5.3 pin

### DIFF
--- a/.claude/launch.json
+++ b/.claude/launch.json
@@ -1,0 +1,11 @@
+{
+  "version": "0.0.1",
+  "configurations": [
+    {
+      "name": "evidence-dev",
+      "runtimeExecutable": "npm",
+      "runtimeArgs": ["run", "dev:preview"],
+      "port": 3000
+    }
+  ]
+}

--- a/.envrc
+++ b/.envrc
@@ -1,0 +1,27 @@
+# direnv config — run `direnv allow` once after cloning/editing.
+#
+# Resolves the MotherDuck token for the Evidence `nfcore_db` source from 1Password
+# and exports it, so EVERY tool launched in this repo (npm, Claude Code, Cursor's
+# terminal, the Python pipeline) inherits it. The token never touches disk.
+#
+# Safe to commit: the line below is a 1Password *reference*, not the secret itself.
+# See AGENTS.md › "Data source / MotherDuck caveat" for the full story.
+#
+# Requires: direnv + 1Password CLI (`op`), signed in (desktop-app unlock or `op signin`).
+
+# 1Password account + secret reference (op://<vault>/<item>/<field>).
+# The `Dev` vault lives in the nf-core account, so scope the read to it explicitly —
+# otherwise `op` resolves against your default account and reports "Dev isn't a vault".
+EVIDENCE_TOKEN_OP_ACCOUNT="nf-core.1password.eu"
+EVIDENCE_TOKEN_OP_REF="op://Dev/Motherduck stats dev token/credential"
+
+if command -v op >/dev/null 2>&1; then
+  if _md_token="$(op read --account "$EVIDENCE_TOKEN_OP_ACCOUNT" "$EVIDENCE_TOKEN_OP_REF" 2>/dev/null)" && [ -n "$_md_token" ]; then
+    export EVIDENCE_SOURCE__nfcore_db__token="$_md_token"
+  else
+    log_error "direnv: could not read $EVIDENCE_TOKEN_OP_REF from 1Password (try 'op signin'). Evidence will show no data."
+  fi
+  unset _md_token
+else
+  log_status "direnv: 1Password CLI 'op' not found — skipping MotherDuck token. Install op, or export EVIDENCE_SOURCE__nfcore_db__token yourself."
+fi

--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@ static/data
 .vscode/settings.json
 .env
 .evidence/meta
+.claude/settings.local.json
 *.pyc
 __pycache__
 regulatory

--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@ static/data
 *.options.yaml
 .vscode/settings.json
 .env
+.direnv
 .evidence/meta
 .claude/settings.local.json
 *.pyc

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -28,6 +28,12 @@ Evidence runs that file's values through a base64 decode, so a raw JWT makes it 
 "Error parsing connection.options.yaml". The env-var form is set verbatim and is the reliable path.
 With the token, all source queries (GitHub, Slack, Twitter, traffic, issues, contributors) populate.
 
+**DuckDB version pin (gotcha):** MotherDuck only supports DuckDB **≤ v1.5.3**, but
+`@evidence-dev/duckdb` pulls an older `@duckdb/node-api` (DuckDB 1.4.2). `package.json` carries an
+`overrides` entry forcing `@duckdb/node-api` to `1.5.3-r.3` so `evidence sources` can connect. If a
+MotherDuck error reports an unsupported DuckDB version (too old **or** too new), change that override
+to the version MotherDuck names and re-run `npm install`.
+
 #### Supplying the token via 1Password + direnv (recommended)
 
 The token lives in **1Password**; share it between developers and agents by *reference*, never by

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -28,6 +28,30 @@ Evidence runs that file's values through a base64 decode, so a raw JWT makes it 
 "Error parsing connection.options.yaml". The env-var form is set verbatim and is the reliable path.
 With the token, all source queries (GitHub, Slack, Twitter, traffic, issues, contributors) populate.
 
+#### Supplying the token via 1Password + direnv (recommended)
+
+The token lives in **1Password**; share it between developers and agents by *reference*, never by
+value. The committed `.envrc` resolves it with the 1Password CLI (`op`) and exports
+`EVIDENCE_SOURCE__nfcore_db__token`, so anything launched from this directory inherits it — the
+secret never lands on disk and **no agent config holds the token**.
+
+One-time per machine: install `direnv` + `op`, sign in to `op`, confirm the `op://…` reference in
+`.envrc` matches where the team stores the token, then run `direnv allow`. After that
+`npm run sources`, `npm run dev:preview`, and the Claude preview pick the token up automatically.
+
+Per runtime:
+
+- **Claude Code / Cursor (local):** launched from a shell in this repo, so they inherit the direnv
+  environment — nothing else to configure. If you launch the desktop app *outside* a direnv shell,
+  start it from a terminal in this repo, or (Claude only) paste the raw token into the gitignored
+  `.claude/settings.local.json` `env` block as a fallback.
+- **Cursor Cloud / other headless agents:** no interactive `op`. Set
+  `EVIDENCE_SOURCE__nfcore_db__token` directly in the environment settings, or use an `op`
+  service-account token (`OP_SERVICE_ACCOUNT_TOKEN`) with `op run`.
+- **CI / Netlify:** unchanged. GitHub Actions reads `secrets.MOTHERDUCK_TOKEN`
+  (`.github/workflows/run_pipelines.yml`); the Netlify build reads its own env var set in the
+  Netlify UI. Never commit the token.
+
 ### Running fully locally without MotherDuck
 
 You can exercise both services end-to-end without the MotherDuck token:

--- a/package-lock.json
+++ b/package-lock.json
@@ -708,93 +708,6 @@
         "apache-arrow": "^17.0.0"
       }
     },
-    "node_modules/@duckdb/node-api": {
-      "version": "1.4.2-r.1",
-      "resolved": "https://registry.npmjs.org/@duckdb/node-api/-/node-api-1.4.2-r.1.tgz",
-      "integrity": "sha512-8Ef4R/Lq+rXTpcqZIJZe6ALfgMGxy88HmiPvRpWrRw1fUTy85x1U0NnGrqCklZsmWyZUdPwVYj90MQOF2MY/TA==",
-      "license": "MIT",
-      "dependencies": {
-        "@duckdb/node-bindings": "1.4.2-r.1"
-      }
-    },
-    "node_modules/@duckdb/node-bindings": {
-      "version": "1.4.2-r.1",
-      "resolved": "https://registry.npmjs.org/@duckdb/node-bindings/-/node-bindings-1.4.2-r.1.tgz",
-      "integrity": "sha512-z0pJCdEnIj0Famkip6w7JZ/A17nm5VcYc6H7isOHXfEnPhBQ9PBusUTFgIzl6+3J8HOFQOv0szJq46zldbsHfQ==",
-      "license": "MIT",
-      "optionalDependencies": {
-        "@duckdb/node-bindings-darwin-arm64": "1.4.2-r.1",
-        "@duckdb/node-bindings-darwin-x64": "1.4.2-r.1",
-        "@duckdb/node-bindings-linux-arm64": "1.4.2-r.1",
-        "@duckdb/node-bindings-linux-x64": "1.4.2-r.1",
-        "@duckdb/node-bindings-win32-x64": "1.4.2-r.1"
-      }
-    },
-    "node_modules/@duckdb/node-bindings-darwin-arm64": {
-      "version": "1.4.2-r.1",
-      "resolved": "https://registry.npmjs.org/@duckdb/node-bindings-darwin-arm64/-/node-bindings-darwin-arm64-1.4.2-r.1.tgz",
-      "integrity": "sha512-C4yBI3zBX7iZ9iq8zJDvPatXA+2xM22sg1kX3fx76nG+qTqKtU/dGFVYL7Fx6cBYxBO1ZZ8Y+vjgYb6/bich8A==",
-      "cpu": [
-        "arm64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "darwin"
-      ]
-    },
-    "node_modules/@duckdb/node-bindings-darwin-x64": {
-      "version": "1.4.2-r.1",
-      "resolved": "https://registry.npmjs.org/@duckdb/node-bindings-darwin-x64/-/node-bindings-darwin-x64-1.4.2-r.1.tgz",
-      "integrity": "sha512-dgTSBuEfWyhymYovsGoRESjqcJuZWwJqla9l89SSsBDrGYcUp+EHsXUF73oUCspzTesT2lOvHrDufO8pKgtudw==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "darwin"
-      ]
-    },
-    "node_modules/@duckdb/node-bindings-linux-arm64": {
-      "version": "1.4.2-r.1",
-      "resolved": "https://registry.npmjs.org/@duckdb/node-bindings-linux-arm64/-/node-bindings-linux-arm64-1.4.2-r.1.tgz",
-      "integrity": "sha512-r2Ml1LvU2vkVMx4YU04T79FjGkYg8YMVtbOz7j740SZGIi5Cch5P1/oy48jJBWRqoaXuqimpYWeTZiGVeCQiZA==",
-      "cpu": [
-        "arm64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ]
-    },
-    "node_modules/@duckdb/node-bindings-linux-x64": {
-      "version": "1.4.2-r.1",
-      "resolved": "https://registry.npmjs.org/@duckdb/node-bindings-linux-x64/-/node-bindings-linux-x64-1.4.2-r.1.tgz",
-      "integrity": "sha512-ed5KiNIu1rqSva5rgo4PRVYSmBolAMVqGFWsYWLoRZ94ka2F/dHwJNkarCTmBFCEDGVZWzWzjRyWTQgYTvQxTg==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ]
-    },
-    "node_modules/@duckdb/node-bindings-win32-x64": {
-      "version": "1.4.2-r.1",
-      "resolved": "https://registry.npmjs.org/@duckdb/node-bindings-win32-x64/-/node-bindings-win32-x64-1.4.2-r.1.tgz",
-      "integrity": "sha512-kIIT8tuoW3mzr9EPcdSoKfv9CgOhTqRryHDI10Z0nuhc9UhqOWPUM/LnSUebfo1mdD9Drm7YrKCKYxNTr5dqBQ==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "win32"
-      ]
-    },
     "node_modules/@esbuild/aix-ppc64": {
       "version": "0.25.12",
       "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.25.12.tgz",
@@ -1417,6 +1330,138 @@
         "@duckdb/node-api": "^1.4.2-r.1",
         "@evidence-dev/db-commons": "1.1.0"
       }
+    },
+    "node_modules/@evidence-dev/duckdb/node_modules/@duckdb/node-api": {
+      "version": "1.5.3-r.3",
+      "resolved": "https://registry.npmjs.org/@duckdb/node-api/-/node-api-1.5.3-r.3.tgz",
+      "integrity": "sha512-FzuL6sevuFfEFwkgiUMRMUAj4TaVqV//L0oo2FVZ9s9oYpLpALF9qZyQv2ucclTNQZwDCkm8+e6yLMc6t8IjlA==",
+      "license": "MIT",
+      "dependencies": {
+        "@duckdb/node-bindings": "1.5.3-r.3"
+      }
+    },
+    "node_modules/@evidence-dev/duckdb/node_modules/@duckdb/node-bindings": {
+      "version": "1.5.3-r.3",
+      "resolved": "https://registry.npmjs.org/@duckdb/node-bindings/-/node-bindings-1.5.3-r.3.tgz",
+      "integrity": "sha512-Dphw1a9kKXZnCiWX1YCEAJsQ7WJQO2Ikgxy7m8jy0QVXqAwB9esr5NGsuEL3vMKL7velZHeZCjGOMnHZEcIsdg==",
+      "license": "MIT",
+      "dependencies": {
+        "detect-libc": "^2.1.2"
+      },
+      "optionalDependencies": {
+        "@duckdb/node-bindings-darwin-arm64": "1.5.3-r.3",
+        "@duckdb/node-bindings-darwin-x64": "1.5.3-r.3",
+        "@duckdb/node-bindings-linux-arm64": "1.5.3-r.3",
+        "@duckdb/node-bindings-linux-arm64-musl": "1.5.3-r.3",
+        "@duckdb/node-bindings-linux-x64": "1.5.3-r.3",
+        "@duckdb/node-bindings-linux-x64-musl": "1.5.3-r.3",
+        "@duckdb/node-bindings-win32-arm64": "1.5.3-r.3",
+        "@duckdb/node-bindings-win32-x64": "1.5.3-r.3"
+      }
+    },
+    "node_modules/@evidence-dev/duckdb/node_modules/@duckdb/node-bindings-darwin-arm64": {
+      "version": "1.5.3-r.3",
+      "resolved": "https://registry.npmjs.org/@duckdb/node-bindings-darwin-arm64/-/node-bindings-darwin-arm64-1.5.3-r.3.tgz",
+      "integrity": "sha512-ttD8QBesgzHu7Sc4qouuIGLM7PWedLW8GvFbnZEyMqk24mQz1HWFgaT0ivw6nDRaDPUQLB9QnAOq8MZUh1zWHQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@evidence-dev/duckdb/node_modules/@duckdb/node-bindings-darwin-x64": {
+      "version": "1.5.3-r.3",
+      "resolved": "https://registry.npmjs.org/@duckdb/node-bindings-darwin-x64/-/node-bindings-darwin-x64-1.5.3-r.3.tgz",
+      "integrity": "sha512-Vp9MYtoYf6zUWHdCmHXwUcJlHq3YaaIeULWeSiPUM1hsDflLiZKXtz5i250Ulz03VsfWBjpO4wdM99sjjrYKkg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@evidence-dev/duckdb/node_modules/@duckdb/node-bindings-linux-arm64": {
+      "version": "1.5.3-r.3",
+      "resolved": "https://registry.npmjs.org/@duckdb/node-bindings-linux-arm64/-/node-bindings-linux-arm64-1.5.3-r.3.tgz",
+      "integrity": "sha512-3HLcrzQE83947JS51UVR7C9qnXQMltCOk4Dnhiz1CD+9u32DGLMgPTIIxclk7O+Q7EwfqzD8JV86Ud+LT1crcQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@evidence-dev/duckdb/node_modules/@duckdb/node-bindings-linux-arm64-musl": {
+      "version": "1.5.3-r.3",
+      "resolved": "https://registry.npmjs.org/@duckdb/node-bindings-linux-arm64-musl/-/node-bindings-linux-arm64-musl-1.5.3-r.3.tgz",
+      "integrity": "sha512-IadRyx+98FEynKLXAk2MzReinFgduiDXgNd5Z8c5VKch+8FgBfqkEUYGOnBMMUPT8kuheKdLj23vpWXaCzOgoQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@evidence-dev/duckdb/node_modules/@duckdb/node-bindings-linux-x64": {
+      "version": "1.5.3-r.3",
+      "resolved": "https://registry.npmjs.org/@duckdb/node-bindings-linux-x64/-/node-bindings-linux-x64-1.5.3-r.3.tgz",
+      "integrity": "sha512-TXndAL0ZoETq17Df6wB+SUZjLGDmOsKuDSySxB+wy6sHfpRtbDgQibyXRlajVeUkRDwSzBFC5ymy16YG0Fl4iw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@evidence-dev/duckdb/node_modules/@duckdb/node-bindings-linux-x64-musl": {
+      "version": "1.5.3-r.3",
+      "resolved": "https://registry.npmjs.org/@duckdb/node-bindings-linux-x64-musl/-/node-bindings-linux-x64-musl-1.5.3-r.3.tgz",
+      "integrity": "sha512-5bulS16YhftXcarki4tvCufVslntpQDLOEF6RZ+FSMOGiv5d7SDXqklmVRy4DKW3C5ekgN7S2oYzuGL/ss9BuA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@evidence-dev/duckdb/node_modules/@duckdb/node-bindings-win32-arm64": {
+      "version": "1.5.3-r.3",
+      "resolved": "https://registry.npmjs.org/@duckdb/node-bindings-win32-arm64/-/node-bindings-win32-arm64-1.5.3-r.3.tgz",
+      "integrity": "sha512-55Vu13S0jUudiAGlNWJd7UvlW1iKjwWehD8s93jBCNm0AdE/EJN4nz5rQ0IuWzPWXpMjAYuKu00yE7NdtbTyug==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@evidence-dev/duckdb/node_modules/@duckdb/node-bindings-win32-x64": {
+      "version": "1.5.3-r.3",
+      "resolved": "https://registry.npmjs.org/@duckdb/node-bindings-win32-x64/-/node-bindings-win32-x64-1.5.3-r.3.tgz",
+      "integrity": "sha512-rlOc9ltWQNHuDq99Ah8XaD80nN1ucrSK5AcH/7ibSp9ogX/jswPYlRVE7ODFJAjnQNf8bVvs++Mp+wyGvuG7ag==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
     },
     "node_modules/@evidence-dev/evidence": {
       "version": "40.1.6",
@@ -5503,6 +5548,15 @@
       "resolved": "https://registry.npmjs.org/detect-indent/-/detect-indent-6.1.0.tgz",
       "integrity": "sha512-reYkTUJAZb9gUuZ2RvVCNhVHdg62RHnJ7WJl8ftMi4diZ6NWlciOzQN88pUhSELEwflJht4oQDv0F0BMlwaYtA==",
       "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/detect-libc": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
+      "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
+      "license": "Apache-2.0",
       "engines": {
         "node": ">=8"
       }

--- a/package.json
+++ b/package.json
@@ -22,5 +22,8 @@
     "@evidence-dev/duckdb": "^2.0.0",
     "@evidence-dev/evidence": "^40.1.6",
     "@evidence-dev/motherduck": "^1.0.5"
+  },
+  "overrides": {
+    "@duckdb/node-api": "1.5.3-r.3"
   }
 }

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
     "build": "evidence build",
     "build:strict": "evidence build:strict",
     "dev": "evidence dev --open /",
-    "dev:preview": "evidence dev",
+    "dev:preview": "sh scripts/dev-preview.sh",
     "test": "evidence build",
     "sources": "evidence sources",
     "preview": "evidence preview"

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
     "build": "evidence build",
     "build:strict": "evidence build:strict",
     "dev": "evidence dev --open /",
+    "dev:preview": "evidence dev",
     "test": "evidence build",
     "sources": "evidence sources",
     "preview": "evidence preview"

--- a/scripts/dev-preview.sh
+++ b/scripts/dev-preview.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env sh
+# Chains the Evidence data build into the dev server, used by `npm run dev:preview`
+# and the Claude preview config (.claude/launch.json).
+#
+# `evidence sources` fetches data from MotherDuck and needs a token
+# (EVIDENCE_SOURCE__nfcore_db__token — see AGENTS.md "Data source / MotherDuck caveat").
+# Behaviour:
+#   - token set:   build sources, then serve (a partial/failed build still serves)
+#   - no token:    skip the fetch so the dev server starts instantly with no data,
+#                  instead of hanging on a MotherDuck connection that can't authenticate
+set -e
+
+if [ -n "$EVIDENCE_SOURCE__nfcore_db__token" ]; then
+  echo "[dev:preview] Building sources from MotherDuck…"
+  evidence sources || echo "[dev:preview] some sources failed; serving with whatever built"
+else
+  echo "[dev:preview] EVIDENCE_SOURCE__nfcore_db__token not set — skipping sources; dashboard will show no data (see AGENTS.md)"
+fi
+
+exec evidence dev


### PR DESCRIPTION
## What

Sets up local previewing of the Evidence dashboard for AI agents (Claude Code, Cursor) and humans, wires the MotherDuck token securely from 1Password, and fixes a DuckDB version incompatibility that broke `evidence sources`.

### Changes
- **`.claude/launch.json`** — Claude preview config; runs `npm run dev:preview` on port 3000.
- **`scripts/dev-preview.sh` + `dev:preview` script** — chains `evidence sources` before `evidence dev`. Builds sources when a token is present; **skips gracefully when it isn't**, so the dev server boots in ~3s instead of hanging on a MotherDuck connection timeout (the old "launches weird" symptom).
- **`.envrc`** — direnv resolves `EVIDENCE_SOURCE__nfcore_db__token` from 1Password (`op read op://Dev/Motherduck stats dev token/credential`) and exports it. Every tool launched in the repo inherits it — **no secret on disk, none in any agent config.** Guarded so a missing/locked `op` warns instead of breaking the shell.
- **`package.json` override** — pins `@duckdb/node-api` to `1.5.3-r.3`. `@evidence-dev/duckdb` otherwise pulls DuckDB 1.4.2 (and stale installs were on 1.1.3); MotherDuck accepts only DuckDB ≤ v1.5.3.
- **`AGENTS.md`** — documents the per-runtime token workflow (Claude/Cursor local, Cursor Cloud, CI/Netlify) and the DuckDB version gotcha.
- **`.gitignore`** — ignores the `.direnv` cache.

## Why

- The dashboard reads from MotherDuck (cloud DuckDB). Agents/devs need a fast, secure way to run a live preview without pasting the token into per-tool configs.
- `evidence sources` was failing at `motherduck_init`: the bundled DuckDB (1.1.3, later 1.4.2) is rejected by MotherDuck, which requires ≤ v1.5.3.

## Verification

- direnv loads the token: `ref OK` → `TOKEN_LOADED` → `export +EVIDENCE_SOURCE__nfcore_db__token`.
- With the override, `evidence sources` loads the **v1.5.3** MotherDuck extension and gets past the version check — it now fails only on auth when no token is present (proving the version fix; real token connects).

## Reviewer notes

- The DuckDB pin also unblocks the **Netlify production build**, which runs `evidence build` against MotherDuck from this same lockfile.
- 1Password's desktop-app integration only authorizes the terminal it's tied to, so for the Claude preview to show **live data**, launch Claude Code from a terminal where `direnv allow` has loaded the token.
- MotherDuck's supported-DuckDB window is narrow (≤ 1.5.3; 1.5.4 is rejected as "too new"). If a future Evidence/npm bump drifts off 1.5.3, update the `overrides` pin.

🤖 Generated with [Claude Code](https://claude.com/claude-code)