### PR TITLE
Track newsletter (AWS SES) subscribers over time

### DIFF
--- a/.github/workflows/run_pipelines.yml
+++ b/.github/workflows/run_pipelines.yml
@@ -56,11 +56,11 @@ jobs:
             uuid: 585d7c4f-abc9-49fa-980f-64d950d6fd2b
           - pipeline: citations
             uuid: 40694d0-50ed-4bb7-919d-463d3555b23f
-          - pipeline: ses
+          - pipeline: newsletter
             uuid: aed8f97c-1c53-4cca-923e-7b969acee876
     permissions:
       contents: read
-      id-token: write # AWS OIDC (SES pipeline only)
+      id-token: write # AWS OIDC (newsletter pipeline only)
     defaults:
       run:
         working-directory: pipeline
@@ -74,10 +74,10 @@ jobs:
         uses: astral-sh/setup-uv@61cb8a9741eeb8a550a1b8544337180c0fc8476b # v7
         with:
           python-version: "3.10"
-          # The SES leg's run step is skipped on PRs, so uv never installs
+          # The newsletter leg's run step is skipped on PRs, so uv never installs
           # anything and no cache dir is created — enabling the cache would then
           # make setup-uv's post step fail on the missing dir. Disable it there.
-          enable-cache: ${{ !(matrix.pipeline == 'ses' && github.event_name == 'pull_request') }}
+          enable-cache: ${{ !(matrix.pipeline == 'newsletter' && github.event_name == 'pull_request') }}
           cache-dependency-glob: |
             **/pyproject.toml
             **/uv.lock
@@ -94,17 +94,17 @@ jobs:
           ./runitor -version
           sudo mv runitor /usr/local/bin/
 
-      # The SES pipeline reads the newsletter contact list via the AWS SES API.
+      # The newsletter pipeline reads the contact list via the AWS SES API.
       - name: Configure AWS credentials
-        if: matrix.pipeline == 'ses' && github.event_name != 'pull_request'
+        if: matrix.pipeline == 'newsletter' && github.event_name != 'pull_request'
         uses: aws-actions/configure-aws-credentials@e7f100cf4c008499ea8adda475de1042d6975c7b # v6.2.0
         with:
           role-to-assume: ${{ secrets.AWS_ROLE_ARN }}
           aws-region: eu-west-1
 
       - name: Get ${{ matrix.pipeline }} stats
-        # SES has no credentials on PRs (OIDC isn't available to forks), so skip it there.
-        if: ${{ !(matrix.pipeline == 'ses' && github.event_name == 'pull_request') }}
+        # newsletter has no credentials on PRs (OIDC isn't available to forks), so skip it there.
+        if: ${{ !(matrix.pipeline == 'newsletter' && github.event_name == 'pull_request') }}
         run: |
           runitor -uuid ${{ matrix.uuid }} -- \
               uv run nf_core_stats ${{ matrix.pipeline }} ${{ github.event_name == 'pull_request' && '--destination duckdb' || '' }}

--- a/.github/workflows/run_pipelines.yml
+++ b/.github/workflows/run_pipelines.yml
@@ -14,6 +14,10 @@ name: Run All Pipelines
       - "pipeline/**"
       - ".github/workflows/run_pipelines.yml"
 
+# Minimal default; the run_pipelines job alone raises id-token for AWS OIDC.
+permissions:
+  contents: read
+
 env:
   SOURCES__GITHUB_PIPELINE__GITHUB__API_TOKEN: ${{ secrets.GH_TOKEN_STATS_PAGE }}
   SOURCES__SLACK_PIPELINE__SLACK__API_TOKEN: ${{ secrets.SLACK_USER_TOKEN }}
@@ -52,12 +56,19 @@ jobs:
             uuid: 585d7c4f-abc9-49fa-980f-64d950d6fd2b
           - pipeline: citations
             uuid: 40694d0-50ed-4bb7-919d-463d3555b23f
+          - pipeline: ses
+            uuid: aed8f97c-1c53-4cca-923e-7b969acee876
+    permissions:
+      contents: read
+      id-token: write # AWS OIDC (SES pipeline only)
     defaults:
       run:
         working-directory: pipeline
     steps:
       - name: Checkout repository
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+        with:
+          persist-credentials: false
 
       - name: Set up uv
         uses: astral-sh/setup-uv@61cb8a9741eeb8a550a1b8544337180c0fc8476b # v7
@@ -80,7 +91,17 @@ jobs:
           ./runitor -version
           sudo mv runitor /usr/local/bin/
 
+      # The SES pipeline reads the newsletter contact list via the AWS SES API.
+      - name: Configure AWS credentials
+        if: matrix.pipeline == 'ses' && github.event_name != 'pull_request'
+        uses: aws-actions/configure-aws-credentials@e7f100cf4c008499ea8adda475de1042d6975c7b # v6.2.0
+        with:
+          role-to-assume: ${{ secrets.AWS_ROLE_ARN }}
+          aws-region: eu-west-1
+
       - name: Get ${{ matrix.pipeline }} stats
+        # SES has no credentials on PRs (OIDC isn't available to forks), so skip it there.
+        if: ${{ !(matrix.pipeline == 'ses' && github.event_name == 'pull_request') }}
         run: |
           runitor -uuid ${{ matrix.uuid }} -- \
               uv run nf_core_stats ${{ matrix.pipeline }} ${{ github.event_name == 'pull_request' && '--destination duckdb' || '' }}

--- a/.github/workflows/run_pipelines.yml
+++ b/.github/workflows/run_pipelines.yml
@@ -74,10 +74,10 @@ jobs:
         uses: astral-sh/setup-uv@61cb8a9741eeb8a550a1b8544337180c0fc8476b # v7
         with:
           python-version: "3.10"
-          enable-cache: true
-          # Per-pipeline suffix so concurrent matrix jobs don't race to save the
-          # same cache key when the lockfile changes (all 4 miss, then collide).
-          cache-suffix: ${{ matrix.pipeline }}
+          # The SES leg's run step is skipped on PRs, so uv never installs
+          # anything and no cache dir is created — enabling the cache would then
+          # make setup-uv's post step fail on the missing dir. Disable it there.
+          enable-cache: ${{ !(matrix.pipeline == 'ses' && github.event_name == 'pull_request') }}
           cache-dependency-glob: |
             **/pyproject.toml
             **/uv.lock

--- a/.github/workflows/run_pipelines.yml
+++ b/.github/workflows/run_pipelines.yml
@@ -75,6 +75,9 @@ jobs:
         with:
           python-version: "3.10"
           enable-cache: true
+          # Per-pipeline suffix so concurrent matrix jobs don't race to save the
+          # same cache key when the lockfile changes (all 4 miss, then collide).
+          cache-suffix: ${{ matrix.pipeline }}
           cache-dependency-glob: |
             **/pyproject.toml
             **/uv.lock

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -53,6 +53,7 @@ The MotherDuck database contains tables for:
 - `github_issue_stats` - Issues and pull requests
 - `slack_messages` - Slack channel message counts
 - `slack_members` - Slack member statistics
+- `ses.newsletter_stats` - AWS SES newsletter subscriber counts (subscribed, pending, unsubscribed)
 
 ### Environment Variables
 
@@ -62,6 +63,7 @@ Required secrets for pipelines (set in GitHub Actions or local `.env`):
 - `SOURCES__SLACK_PIPELINE__SLACK__API_TOKEN` - Slack user token
 - `DESTINATION__MOTHERDUCK__CREDENTIALS__DATABASE` - MotherDuck database name
 - `DESTINATION__MOTHERDUCK__CREDENTIALS__PASSWORD` - MotherDuck token
+- `AWS_ROLE_ARN` - IAM role (assumed via OIDC in CI) with `ses:ListContacts` for the `ses` pipeline
 
 ## Development Notes
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -53,7 +53,7 @@ The MotherDuck database contains tables for:
 - `github_issue_stats` - Issues and pull requests
 - `slack_messages` - Slack channel message counts
 - `slack_members` - Slack member statistics
-- `ses.newsletter_stats` - AWS SES newsletter subscriber counts (subscribed, pending, unsubscribed)
+- `newsletter.subscriber_stats` - AWS SES newsletter subscriber counts (subscribed, pending, unsubscribed)
 
 ### Environment Variables
 
@@ -63,7 +63,7 @@ Required secrets for pipelines (set in GitHub Actions or local `.env`):
 - `SOURCES__SLACK_PIPELINE__SLACK__API_TOKEN` - Slack user token
 - `DESTINATION__MOTHERDUCK__CREDENTIALS__DATABASE` - MotherDuck database name
 - `DESTINATION__MOTHERDUCK__CREDENTIALS__PASSWORD` - MotherDuck token
-- `AWS_ROLE_ARN` - IAM role (assumed via OIDC in CI) with `ses:ListContacts` for the `ses` pipeline
+- `AWS_ROLE_ARN` - IAM role (assumed via OIDC in CI) with `ses:ListContacts` for the `newsletter` pipeline
 
 ## Development Notes
 

--- a/pages/community/newsletter.md
+++ b/pages/community/newsletter.md
@@ -1,0 +1,38 @@
+---
+title: Newsletter
+sidebar_position: 3
+---
+
+The nf-core monthly newsletter rounds up community news, new pipeline releases, events and more. Sign up (double opt-in, one-click unsubscribe) at [nf-co.re/newsletter](https://nf-co.re/newsletter). Subscriptions are managed with Amazon SES.
+
+```sql view_days
+select
+    timestamp
+from newsletter_subscribers
+group by 1 order by 1 desc
+```
+
+<DateRange
+    name=range_filtering_a_query
+    data={view_days}
+    dates=timestamp
+    defaultValue="All Time"
+    for
+/>
+
+```subscribers_filtered
+select distinct * from newsletter_subscribers
+where timestamp between '${inputs.range_filtering_a_query.start}' and ('${inputs.range_filtering_a_query.end}'::date + interval '1 day')
+order by 1 desc
+```
+
+<LineChart
+data={subscribers_filtered}
+x=timestamp
+y=value
+series=category
+title="nf-core newsletter subscribers over time"
+subtitle="Per day from {inputs.range_filtering_a_query.start} to {inputs.range_filtering_a_query.end}"
+/>
+
+ℹ️ **Subscribed** contacts have confirmed their email address (completed double opt-in) and receive the newsletter. **Pending** contacts have signed up but not yet confirmed.

--- a/pages/index.md
+++ b/pages/index.md
@@ -4,6 +4,7 @@ queries:
   - community/growth_gh_members.sql
   - community/growth_slack_users.sql
   - community/growth_gh_contributors.sql
+  - community/growth_newsletter_subscribers.sql
   - code/growth_gh_repos.sql
   - code/growth_gh_released_repos.sql
   - code/growth_gh_commits.sql
@@ -42,6 +43,16 @@ The numbers below track our growth over the various channels that the nf-core co
   title="GitHub Contributors"
   sparkline=month
   link="/community/github"
+  fmt=num0
+  minWidth=30%
+/>
+
+<BigValue
+  data={community_growth_newsletter_subscribers}
+  value=subscribers
+  title="Newsletter Subscribers"
+  sparkline=month
+  link="/community/newsletter"
   fmt=num0
   minWidth=30%
 />

--- a/pipeline/README.md
+++ b/pipeline/README.md
@@ -44,7 +44,7 @@ DESTINATION__MOTHERDUCK__CREDENTIALS__PASSWORD                        # motherdu
 DESTINATION__DUCKDB__CREDENTIALS="./nf_core_stats.duckdb"
 ```
 
-The `ses` pipeline (newsletter subscriber counts) reads the AWS SES contact list
+The `newsletter` pipeline (subscriber counts) reads the AWS SES contact list
 via `boto3`, so it uses standard AWS credentials from the environment rather than
 a `dlt` secret. In GitHub Actions these come from OIDC role assumption
 (`secrets.AWS_ROLE_ARN`); locally, set the usual AWS variables:
@@ -112,8 +112,8 @@ Database: nf_core_stats
 │   └── Table: workspace_stats
 │       └── (user counts, activity metrics)
 │
-├── Schema: ses
-│   └── Table: newsletter_stats
+├── Schema: newsletter
+│   └── Table: subscriber_stats
 │       └── (newsletter subscriber counts: subscribed, pending, unsubscribed)
 │
 └── Schema: twitter

--- a/pipeline/README.md
+++ b/pipeline/README.md
@@ -44,6 +44,19 @@ DESTINATION__MOTHERDUCK__CREDENTIALS__PASSWORD                        # motherdu
 DESTINATION__DUCKDB__CREDENTIALS="./nf_core_stats.duckdb"
 ```
 
+The `ses` pipeline (newsletter subscriber counts) reads the AWS SES contact list
+via `boto3`, so it uses standard AWS credentials from the environment rather than
+a `dlt` secret. In GitHub Actions these come from OIDC role assumption
+(`secrets.AWS_ROLE_ARN`); locally, set the usual AWS variables:
+
+```bash
+AWS_ACCESS_KEY_ID
+AWS_SECRET_ACCESS_KEY
+# region is hard-coded to eu-west-1 to match the nf-core/newsletter list
+```
+
+The credentials need `ses:ListContacts` on the `nf-core-newsletter` contact list.
+
 `dotenv` can retrieve them from 1password automatically, see `.envrc` for more details. If you
 are not using `dotenv`, you need to set these env vars manually.
 
@@ -98,6 +111,10 @@ Database: nf_core_stats
 ├── Schema: slack
 │   └── Table: workspace_stats
 │       └── (user counts, activity metrics)
+│
+├── Schema: ses
+│   └── Table: newsletter_stats
+│       └── (newsletter subscriber counts: subscribed, pending, unsubscribed)
 │
 └── Schema: twitter
     └── Table: account_stats

--- a/pipeline/pyproject.toml
+++ b/pipeline/pyproject.toml
@@ -8,6 +8,7 @@ version = "0.1.0"
 description = "DLT pipeline for nf-core stats collection"
 authors = [{ name = "nf-core team" }]
 dependencies = [
+    "boto3>=1.35.0",
     "cyclopts>=4.1.0",
     "dlt[cli,duckdb,motherduck]>=1.18.2",
     "python-dotenv==1.2.2",

--- a/pipeline/src/nf_core_stats/__init__.py
+++ b/pipeline/src/nf_core_stats/__init__.py
@@ -3,7 +3,7 @@ from importlib.metadata import version
 from cyclopts import App
 from dotenv import load_dotenv
 
-from . import citations_pipeline, github_pipeline, slack_pipeline
+from . import citations_pipeline, github_pipeline, ses_pipeline, slack_pipeline
 
 __version__ = version("nf_core_stats")
 
@@ -14,6 +14,7 @@ app = App()
 app.command(github_pipeline.main, "github")
 app.command(slack_pipeline.main, "slack")
 app.command(citations_pipeline.main, "citations")
+app.command(ses_pipeline.main, "ses")
 
 
 if __name__ == "__main__":

--- a/pipeline/src/nf_core_stats/__init__.py
+++ b/pipeline/src/nf_core_stats/__init__.py
@@ -3,7 +3,7 @@ from importlib.metadata import version
 from cyclopts import App
 from dotenv import load_dotenv
 
-from . import citations_pipeline, github_pipeline, ses_pipeline, slack_pipeline
+from . import citations_pipeline, github_pipeline, newsletter_pipeline, slack_pipeline
 
 __version__ = version("nf_core_stats")
 
@@ -14,7 +14,7 @@ app = App()
 app.command(github_pipeline.main, "github")
 app.command(slack_pipeline.main, "slack")
 app.command(citations_pipeline.main, "citations")
-app.command(ses_pipeline.main, "ses")
+app.command(newsletter_pipeline.main, "newsletter")
 
 
 if __name__ == "__main__":

--- a/pipeline/src/nf_core_stats/newsletter_pipeline.py
+++ b/pipeline/src/nf_core_stats/newsletter_pipeline.py
@@ -70,15 +70,15 @@ def _iter_all_contacts(client: Any) -> Iterator[dict[str, Any]]:
             return
 
 
-@dlt.source(name="ses")
-def ses_source() -> list[Any]:
+@dlt.source(name="newsletter")
+def newsletter_source() -> list[Any]:
     """DLT source for AWS SES newsletter list statistics."""
     client = boto3.client("sesv2", region_name=AWS_REGION)
-    return [ses_stats_resource(client)]
+    return [subscriber_stats_resource(client)]
 
 
-@dlt.resource(name="newsletter_stats", write_disposition="merge", primary_key=["timestamp"])
-def ses_stats_resource(client: Any) -> Iterator[dict[str, Any]]:
+@dlt.resource(name="subscriber_stats", write_disposition="merge", primary_key=["timestamp"])
+def subscriber_stats_resource(client: Any) -> Iterator[dict[str, Any]]:
     """Snapshot the newsletter contact list: subscribed, pending and unsubscribed counts."""
     total = 0
     subscribed = 0
@@ -118,12 +118,12 @@ def main(*, destination="motherduck"):
     logger.info("Starting AWS SES newsletter data pipeline...")
 
     pipeline = dlt.pipeline(
-        pipeline_name="ses_stats",
+        pipeline_name="newsletter_stats",
         destination=destination,
-        dataset_name="ses",
+        dataset_name="newsletter",
     )
 
-    load_info = pipeline.run(ses_source())
+    load_info = pipeline.run(newsletter_source())
     log_pipeline_stats(pipeline, load_info)
 
     logger.info("AWS SES newsletter data pipeline completed successfully!")

--- a/pipeline/src/nf_core_stats/ses_pipeline.py
+++ b/pipeline/src/nf_core_stats/ses_pipeline.py
@@ -1,0 +1,129 @@
+"""DLT pipeline for collecting AWS SES newsletter list statistics.
+
+The nf-core monthly newsletter (https://github.com/nf-core/newsletter) uses
+Amazon SES list management as its contact store. A contact is a *subscriber*
+once it is opted in to the ``monthly-newsletter`` topic (double opt-in); before
+confirming it sits on the list opted out, and a global unsubscribe sets
+``UnsubscribeAll``.
+
+This pipeline snapshots those counts once per run so we can chart newsletter
+sign-ups over time alongside the other community stats.
+
+Authentication:
+- Uses boto3, which reads standard AWS credentials from the environment
+  (``AWS_ACCESS_KEY_ID`` / ``AWS_SECRET_ACCESS_KEY``, or an assumed role via
+  OIDC in GitHub Actions).
+- The credentials need ``ses:ListContacts`` on the ``nf-core-newsletter``
+  contact list, which lives in ``eu-west-1``.
+"""
+
+from collections.abc import Iterator
+from datetime import datetime, timezone
+from typing import Any
+
+import boto3
+import dlt
+
+from ._logging import log_pipeline_stats, logger
+
+# Mirrors nf-core/newsletter src/nf_core_newsletter/config.py defaults.
+AWS_REGION = "eu-west-1"
+CONTACT_LIST_NAME = "nf-core-newsletter"
+TOPIC_NAME = "monthly-newsletter"
+
+# SES topic subscription status the newsletter service sets on opt-in.
+OPT_IN = "OPT_IN"
+
+# Max page size accepted by the SES v2 ListContacts API.
+SES_PAGE_SIZE = 1000
+
+
+def _is_subscribed(contact: dict[str, Any]) -> bool:
+    """True if the contact is opted in to the newsletter topic and not globally unsubscribed.
+
+    Matches the logic in nf-core/newsletter ``ses.is_subscribed``.
+    """
+    if contact.get("UnsubscribeAll"):
+        return False
+    for pref in contact.get("TopicPreferences", []):
+        if pref.get("TopicName") == TOPIC_NAME:
+            return pref.get("SubscriptionStatus") == OPT_IN
+    return False
+
+
+def _iter_all_contacts(client: Any) -> Iterator[dict[str, Any]]:
+    """Yield every contact on the list (no filter), paginating as needed.
+
+    ``ListContacts`` returns ``TopicPreferences`` and ``UnsubscribeAll`` on each
+    contact, so we can classify subscribed / pending / unsubscribed without a
+    per-contact ``GetContact`` call.
+    """
+    next_token: str | None = None
+    while True:
+        kwargs: dict[str, Any] = {"ContactListName": CONTACT_LIST_NAME, "PageSize": SES_PAGE_SIZE}
+        if next_token:
+            kwargs["NextToken"] = next_token
+        response = client.list_contacts(**kwargs)
+        yield from response.get("Contacts", [])
+        next_token = response.get("NextToken")
+        if not next_token:
+            return
+
+
+@dlt.source(name="ses")
+def ses_source() -> list[Any]:
+    """DLT source for AWS SES newsletter list statistics."""
+    client = boto3.client("sesv2", region_name=AWS_REGION)
+    return [ses_stats_resource(client)]
+
+
+@dlt.resource(name="newsletter_stats", write_disposition="merge", primary_key=["timestamp"])
+def ses_stats_resource(client: Any) -> Iterator[dict[str, Any]]:
+    """Snapshot the newsletter contact list: subscribed, pending and unsubscribed counts."""
+    total = 0
+    subscribed = 0
+    unsubscribed = 0
+
+    for contact in _iter_all_contacts(client):
+        total += 1
+        if contact.get("UnsubscribeAll"):
+            unsubscribed += 1
+        elif _is_subscribed(contact):
+            subscribed += 1
+
+    # On the list but neither confirmed nor globally unsubscribed (double opt-in pending).
+    pending = total - subscribed - unsubscribed
+
+    logger.info(
+        f"SES list '{CONTACT_LIST_NAME}': {total} contacts "
+        f"({subscribed} subscribed, {pending} pending, {unsubscribed} unsubscribed)"
+    )
+
+    yield {
+        "timestamp": datetime.now(timezone.utc).strftime("%Y-%m-%d %H:%M:%S"),
+        "total_contacts": total,
+        "subscribed": subscribed,
+        "pending": pending,
+        "unsubscribed": unsubscribed,
+    }
+
+
+def main(*, destination="motherduck"):
+    """
+    Run the AWS SES newsletter data ingestion pipeline
+
+    Args:
+        destination: dlt backend. Use 'motherduck' for production. Can use 'duckdb' for local testing
+    """
+    logger.info("Starting AWS SES newsletter data pipeline...")
+
+    pipeline = dlt.pipeline(
+        pipeline_name="ses_stats",
+        destination=destination,
+        dataset_name="ses",
+    )
+
+    load_info = pipeline.run(ses_source())
+    log_pipeline_stats(pipeline, load_info)
+
+    logger.info("AWS SES newsletter data pipeline completed successfully!")

--- a/pipeline/uv.lock
+++ b/pipeline/uv.lock
@@ -32,6 +32,34 @@ wheels = [
 ]
 
 [[package]]
+name = "boto3"
+version = "1.43.36"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "botocore" },
+    { name = "jmespath" },
+    { name = "s3transfer" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ff/9f/897287e955db0f50b12fd69ef45956e4fd2c7ddb48c736872f7ea2314443/boto3-1.43.36.tar.gz", hash = "sha256:587d7ee92a12e440ad12b0e7f11f3358f0c4d65b19f64726efc94aaf194aff28", size = 112690, upload-time = "2026-06-23T02:47:14.561Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9f/f1/274303f52483ecf199eae6f8d9b6f5951670397ee4d72c06cfd4eb644612/boto3-1.43.36-py3-none-any.whl", hash = "sha256:42942dde254673abcbc9e6e60017c88341a4f49d99d24e1f2e290fb38138c26f", size = 140031, upload-time = "2026-06-23T02:47:13.178Z" },
+]
+
+[[package]]
+name = "botocore"
+version = "1.43.36"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "jmespath" },
+    { name = "python-dateutil" },
+    { name = "urllib3" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/7c/37/da9e7f6ca73ac73afd7f0bb7f238aa5daba35c081e98d7f48a7c399599c0/botocore-1.43.36.tar.gz", hash = "sha256:4cae47d1b2d426316b85a0087d9e69e048f13bc003b5177d74639fe9dfd28205", size = 15625488, upload-time = "2026-06-23T02:47:03.192Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5c/19/934f81592527a3f7f9b943c893e334c721a4644948642bc33885d584e9ec/botocore-1.43.36-py3-none-any.whl", hash = "sha256:3c65fdc39ed01d8dfde1e961b34038aed03c459f8ddf80717a12ac006475e49d", size = 15313630, upload-time = "2026-06-23T02:46:59.327Z" },
+]
+
+[[package]]
 name = "certifi"
 version = "2026.1.4"
 source = { registry = "https://pypi.org/simple" }
@@ -400,6 +428,15 @@ wheels = [
 ]
 
 [[package]]
+name = "jmespath"
+version = "1.1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d3/59/322338183ecda247fb5d1763a6cbe46eff7222eaeebafd9fa65d4bf5cb11/jmespath-1.1.0.tar.gz", hash = "sha256:472c87d80f36026ae83c6ddd0f1d05d4e510134ed462851fd5f754c8c3cbb88d", size = 27377, upload-time = "2026-01-22T16:35:26.279Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/14/2f/967ba146e6d58cf6a652da73885f52fc68001525b4197effc174321d70b4/jmespath-1.1.0-py3-none-any.whl", hash = "sha256:a5663118de4908c91729bea0acadca56526eb2698e83de10cd116ae0f4e97c64", size = 20419, upload-time = "2026-01-22T16:35:24.919Z" },
+]
+
+[[package]]
 name = "jsonpath-ng"
 version = "1.7.0"
 source = { registry = "https://pypi.org/simple" }
@@ -446,6 +483,7 @@ name = "nf-core-stats"
 version = "0.1.0"
 source = { editable = "." }
 dependencies = [
+    { name = "boto3" },
     { name = "cyclopts" },
     { name = "dlt", extra = ["cli", "duckdb", "motherduck"] },
     { name = "python-dotenv" },
@@ -456,6 +494,7 @@ dependencies = [
 
 [package.metadata]
 requires-dist = [
+    { name = "boto3", specifier = ">=1.35.0" },
     { name = "cyclopts", specifier = ">=4.1.0" },
     { name = "dlt", extras = ["cli", "duckdb", "motherduck"], specifier = ">=1.18.2" },
     { name = "python-dotenv", specifier = "==1.2.2" },
@@ -903,6 +942,18 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/bc/6d/a506aaa4a9eaa945ed8ab2b7347859f53593864289853c5d6d62b77246e0/rich_rst-1.3.2.tar.gz", hash = "sha256:a1196fdddf1e364b02ec68a05e8ff8f6914fee10fbca2e6b6735f166bb0da8d4", size = 14936, upload-time = "2025-10-14T16:49:45.332Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/13/2f/b4530fbf948867702d0a3f27de4a6aab1d156f406d72852ab902c4d04de9/rich_rst-1.3.2-py3-none-any.whl", hash = "sha256:a99b4907cbe118cf9d18b0b44de272efa61f15117c61e39ebdc431baf5df722a", size = 12567, upload-time = "2025-10-14T16:49:42.953Z" },
+]
+
+[[package]]
+name = "s3transfer"
+version = "0.19.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "botocore" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/f6/94/dcdaeb1713cab9c84def276cfac7388b17c7d9855bbcfe88d77e4dbafd44/s3transfer-0.19.0.tar.gz", hash = "sha256:ce436931687addc4c1712d52d40b32f53e88315723f107ffa20ba82b05a0f685", size = 165171, upload-time = "2026-06-16T19:44:51.599Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/46/5f/4c174edad94f82de888ac00a5ddd8d07b35609b6c94f0bdf4d74af57703e/s3transfer-0.19.0-py3-none-any.whl", hash = "sha256:777cc2415536f1debadb5c2ef7779275d0fc0fe0e042411cdd6caebeb2685262", size = 90101, upload-time = "2026-06-16T19:44:50.439Z" },
 ]
 
 [[package]]

--- a/queries/community/growth_newsletter_subscribers.sql
+++ b/queries/community/growth_newsletter_subscribers.sql
@@ -1,0 +1,22 @@
+with monthly as (
+    select
+        date_trunc('month', timestamp) as month,
+        max(value) as subscribers
+    from newsletter_subscribers
+    where category = 'subscribed'
+    group by 1
+),
+with_lag as (
+    select
+        month,
+        subscribers,
+        lag(subscribers) over (order by month) as prev_month_subscribers
+    from monthly
+)
+select
+    month,
+    subscribers,
+    prev_month_subscribers,
+    round(cast(subscribers::float / nullif(prev_month_subscribers, 0) - 1 as numeric), 3) as growth_rate
+from with_lag
+order by month desc

--- a/sources/nfcore_db/newsletter_subscribers.sql
+++ b/sources/nfcore_db/newsletter_subscribers.sql
@@ -3,22 +3,13 @@ USE nf_core_stats_bot;
 -- Daily snapshot of the AWS SES newsletter contact list.
 -- One row per category per day (taking the max value for the day, in case the
 -- pipeline ran more than once).
-SELECT
-    timestamp::date AS timestamp,
-    MAX(subscribed) AS value,
-    'subscribed' AS category
-FROM ses.newsletter_stats
-GROUP BY timestamp::date
-
-UNION ALL
-
-SELECT
-    timestamp::date AS timestamp,
-    MAX(pending) AS value,
-    'pending' AS category
-FROM ses.newsletter_stats
-GROUP BY timestamp::date
-
-ORDER BY 1 DESC
+SELECT timestamp::date AS timestamp, value, category
+FROM (
+    SELECT timestamp::date AS timestamp, MAX(subscribed) AS subscribed, MAX(pending) AS pending
+    FROM ses.newsletter_stats
+    GROUP BY 1
+)
+UNPIVOT (value FOR category IN (subscribed, pending))
+ORDER BY timestamp DESC
 
 -- "timestamp","value","category"

--- a/sources/nfcore_db/newsletter_subscribers.sql
+++ b/sources/nfcore_db/newsletter_subscribers.sql
@@ -1,0 +1,24 @@
+USE nf_core_stats_bot;
+
+-- Daily snapshot of the AWS SES newsletter contact list.
+-- One row per category per day (taking the max value for the day, in case the
+-- pipeline ran more than once).
+SELECT
+    timestamp::date AS timestamp,
+    MAX(subscribed) AS value,
+    'subscribed' AS category
+FROM ses.newsletter_stats
+GROUP BY timestamp::date
+
+UNION ALL
+
+SELECT
+    timestamp::date AS timestamp,
+    MAX(pending) AS value,
+    'pending' AS category
+FROM ses.newsletter_stats
+GROUP BY timestamp::date
+
+ORDER BY 1 DESC
+
+-- "timestamp","value","category"

--- a/sources/nfcore_db/newsletter_subscribers.sql
+++ b/sources/nfcore_db/newsletter_subscribers.sql
@@ -6,7 +6,7 @@ USE nf_core_stats_bot;
 SELECT timestamp::date AS timestamp, value, category
 FROM (
     SELECT timestamp::date AS timestamp, MAX(subscribed) AS subscribed, MAX(pending) AS pending
-    FROM ses.newsletter_stats
+    FROM newsletter.subscriber_stats
     GROUP BY 1
 )
 UNPIVOT (value FOR category IN (subscribed, pending))


### PR DESCRIPTION
## What & why

Adds tracking of the number of people signed up to the [nf-core monthly newsletter](https://nf-co.re/newsletter) over time, so it appears in the stats dashboard alongside Slack/GitHub community metrics. The newsletter ([nf-core/newsletter](https://github.com/nf-core/newsletter)) stores subscribers in an AWS SES contact list, so this snapshots that list daily.

<details>

## Changes

- **New `ses` pipeline** (`pipeline/src/nf_core_stats/ses_pipeline.py`) — paginates the SES `nf-core-newsletter` contact list and records **subscribed** / **pending** / **unsubscribed** counts to `ses.newsletter_stats` in MotherDuck. Mirrors the existing `slack`/`citations` pipeline structure. Subscriber classification matches `nf-core/newsletter`'s `ses.is_subscribed` (opted in to the `monthly-newsletter` topic and not globally unsubscribed).
- **Workflow** (`.github/workflows/run_pipelines.yml`) — adds `ses` to the daily matrix using **AWS OIDC** (`secrets.AWS_ROLE_ARN`, read-only `ses:ListContacts`, `eu-west-1`). Skipped on PRs (forks can't get OIDC). Also hardened per `zizmor`: minimal top-level `permissions`, `persist-credentials: false`.
- **Frontend** — `sources/nfcore_db/newsletter_subscribers.sql` + `pages/community/newsletter.md` chart subscribers over time with a date-range filter (same layout as the Slack page).
- Docs (`CLAUDE.md`, `pipeline/README.md`) updated for the new table and AWS auth.

## Infra already provisioned

- IAM role `nf-core-stats-github-actions` created in account `728131696474`, trusting `repo:nf-core/stats:*` via the existing GitHub OIDC provider, with an inline read-only `ses:ListContacts` policy on the `nf-core-newsletter` contact list (verified `allowed` via IAM policy simulation).
- Repo secret `AWS_ROLE_ARN` set.

## Still needed (monitoring)

The new runitor monitor UUID `aed8f97c-1c53-4cca-923e-7b969acee876` needs a matching check created on the healthchecks instance, otherwise its ping is a no-op (the pipeline still runs fine).

## Testing

- Counting logic unit-tested against a mocked paginated SES client (subscribed / pending / unsubscribed / global-unsubscribe all classify correctly).
- `ruff` clean, `zizmor` clean (0 findings), CLI registers the `ses` command.
- Confirmed `ListContacts` works against the live list (6 contacts at time of writing).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

</details>