### PR TITLE
Fix releases bug pipeline timeline & sort based on development days.  

### DIFF
--- a/pages/code/pipelines/timeline.md
+++ b/pages/code/pipelines/timeline.md
@@ -49,7 +49,7 @@ SELECT
     END as release_duration
 FROM nfcore_db.pipeline_timeline
 WHERE development_start >= '2017-01-01'
-ORDER BY start_year DESC, development_start DESC
+ORDER BY start_year DESC, total_days_tracked DESC
 ```
 
 <DataTable

--- a/pipeline/src/nf_core_stats/github_pipeline.py
+++ b/pipeline/src/nf_core_stats/github_pipeline.py
@@ -339,16 +339,21 @@ def pipelines(organization: str, headers: dict, repos: list[dict]) -> Iterator[d
         release_url = f"https://api.github.com/repos/{organization}/{pipeline_name}/releases"
         try:
             releases = get_paginated_data(release_url, headers)
+            # Exclude drafts and prereleases so release reflect stable releases
+            releases = [r for r in releases if r.get("published_at") and not r.get("draft") and not r.get("prerelease")]
             number_of_releases = len(releases)
             if number_of_releases:
                 # releases are sorted by date, starting with the most recent one
                 last_release_date = releases[0].get("published_at")
+                first_release_date = releases[-1].get("published_at")
             else:
                 logger.info(f"No releases found for {pipeline_name} (this is expected for new repositories)")
                 last_release_date = None
+                first_release_date = None
         except requests.RequestException as e:
             logger.warning(f"Failed to get latest release for {pipeline_name}: {e}")
             last_release_date = None
+            first_release_date = None
             number_of_releases = None
 
         yield {
@@ -365,6 +370,7 @@ def pipelines(organization: str, headers: dict, repos: list[dict]) -> Iterator[d
             "default_branch": pipeline["default_branch"],
             "archived": pipeline["archived"],
             "last_release_date": last_release_date,
+            "first_release_date": first_release_date,
             "number_of_releases": number_of_releases,
             "category": "pipeline",
         }

--- a/sources/nfcore_db/pipeline_timeline.sql
+++ b/sources/nfcore_db/pipeline_timeline.sql
@@ -1,30 +1,20 @@
 USE nf_core_stats_bot;
 
 -- Pipeline development timeline - showing development periods for each pipeline
--- Updated to use FIRST release date instead of last release date
-WITH pipeline_first_releases AS (
-    SELECT
-        repo,
-        MIN(published_at) as first_release_date,
-        COUNT(*) as total_releases
-    FROM nf_core_dev.tap_github.releases
-    WHERE published_at IS NOT NULL
-      AND draft = false
-      AND prerelease = false
-    GROUP BY repo
-)
+-- Uses first_release_date/number_of_releases collected directly by the GitHub pipeline
+-- (previously joined against the external nf_core_dev.tap_github.releases
 SELECT
     p.name as pipeline_name,
     p.gh_created_at as development_start,
-    pfr.first_release_date as development_end,
-    COALESCE(pfr.total_releases, 0) as total_releases,
+    p.first_release_date as development_end,
+    COALESCE(p.number_of_releases, 0) as total_releases,
     CASE
-        WHEN pfr.first_release_date IS NOT NULL THEN 'Released'
+        WHEN p.first_release_date IS NOT NULL THEN 'Released'
         ELSE 'In Development'
     END as status,
     -- Calculate development duration in days to FIRST release
     CASE
-        WHEN pfr.first_release_date IS NOT NULL THEN DATE_DIFF('day', p.gh_created_at, pfr.first_release_date)
+        WHEN p.first_release_date IS NOT NULL THEN DATE_DIFF('day', p.gh_created_at, p.first_release_date)
         ELSE DATE_DIFF('day', p.gh_created_at, CURRENT_DATE)
     END as development_days,
     -- Extract year for grouping
@@ -32,6 +22,5 @@ SELECT
     p.stargazers_count,
     p.archived
 FROM github.nfcore_pipelines p
-LEFT JOIN pipeline_first_releases pfr ON pfr.repo = p.name
 WHERE NOT p.archived AND p.category = 'pipeline'
 ORDER BY p.gh_created_at;


### PR DESCRIPTION
While descending sorting `development_start`, intuitively, sorting seems correct; it means that the latest date (the most recent one and not the oldest) is put on top of the table. Resulting in the table to actually be ascending based on the number of devolpment days. 
<img width="1199" height="351" alt="image" src="https://github.com/user-attachments/assets/65448ed3-a4f9-461c-a0e2-80a1afc4f98c" />

Hence, I sorted on `total_days_tracked` instead. 

Also, there was a bug in pipeline releases data; I'm guessing because `nf_core_dev.tap_github.releases` is not updated? It's also the only place where the database was being used. So I instead just added another column in `github.nfcore_pipelines`, which is the first release date. 

Couldn't validate if this new approach is more accurate as I had the following error `Your request is not authenticated. Please check your MotherDuck token. `
```
 $ npm run sources 

> stats@0.0.1 sources
> evidence sources

✔ Loading plugins & sources
-----
  [Processing] nfcore_db
[!] It looks like Motherduck is taking a bit to connect.
    Motherduck connections are only compatible with motherduck >= 0.10.0
    Make sure that you have upgraded your instance to at least 0.10.0
[ ! ] Error connecting to datasource nfcore_db: Invalid Input Error: Initialization function "motherduck_duckdb_cpp_init" from file ".duckdb/extensions/v1.4.2/osx_arm64/motherduck.duckdb_extension" threw an exception: "Invalid Error: Request failed: Your request is not authenticated. Please check your MotherDuck token. (Jwt is not in the form of Header.Payload.Signature with two dots and 3 sections, request id: '')"
```